### PR TITLE
feat: port lovable console ui to liveview

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1,6 +1,3 @@
-/* See the Tailwind configuration guide for advanced usage
-   https://tailwindcss.com/docs/configuration */
-
 @import "tailwindcss" source(none);
 @source "../../deps/ash_authentication_phoenix";
 @source "../../deps/daisy_ui_components";
@@ -8,21 +5,12 @@
 @source "../js";
 @source "../../lib/jido_managed_agents_web";
 
-/* A Tailwind plugin that makes "hero-#{ICON}" classes available.
-   The heroicons installation itself is managed by your mix.exs */
 @plugin "../vendor/heroicons";
 
-/* daisyUI Tailwind Plugin. You can update this file by fetching the latest version with:
-   curl -sLO https://github.com/saadeghi/daisyui/releases/latest/download/daisyui.js
-   Make sure to look at the daisyUI changelog: https://daisyui.com/docs/changelog/ */
 @plugin "../vendor/daisyui" {
   themes: false;
 }
 
-/* daisyUI theme plugin. You can update this file by fetching the latest version with:
-  curl -sLO https://github.com/saadeghi/daisyui/releases/latest/download/daisyui-theme.js
-  We ship with two themes, a light one inspired on Phoenix colors and a dark one inspired
-  on Elixir colors. Build your own at: https://daisyui.com/theme-generator/ */
 @plugin "../vendor/daisyui-theme" {
   name: "dark";
   default: false;
@@ -93,15 +81,887 @@
   --noise: 0;
 }
 
-/* Add variants based on LiveView classes */
 @custom-variant phx-click-loading (.phx-click-loading&, .phx-click-loading &);
 @custom-variant phx-submit-loading (.phx-submit-loading&, .phx-submit-loading &);
 @custom-variant phx-change-loading (.phx-change-loading&, .phx-change-loading &);
-
-/* Use the data attribute for dark mode  */
 @custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
 
-/* Make LiveView wrapper divs transparent for layout */
-[data-phx-session], [data-phx-teleported-src] { display: contents }
+:root,
+[data-theme="light"] {
+  color-scheme: light;
+  --page-bg: #f4f5f7;
+  --panel-bg: #ffffff;
+  --panel-muted: #f8f8f9;
+  --panel-raised: #ffffff;
+  --sidebar-bg: #0f1218;
+  --sidebar-border: rgba(255, 255, 255, 0.08);
+  --sidebar-link: rgba(255, 255, 255, 0.68);
+  --sidebar-link-active-bg: rgba(255, 255, 255, 0.1);
+  --sidebar-link-active: #ffffff;
+  --border-subtle: rgba(18, 23, 32, 0.1);
+  --border-strong: rgba(18, 23, 32, 0.16);
+  --text-strong: #141821;
+  --text-muted: #5d6470;
+  --text-faint: #8b92a1;
+  --brand: #111827;
+  --brand-foreground: #ffffff;
+  --accent: #f59f0b;
+  --accent-soft: rgba(245, 159, 11, 0.12);
+  --session: #0891b2;
+  --session-soft: rgba(8, 145, 178, 0.12);
+  --success: #0f9f6e;
+  --success-soft: rgba(15, 159, 110, 0.12);
+  --danger: #d9485f;
+  --danger-soft: rgba(217, 72, 95, 0.12);
+  --violet: #7c3aed;
+  --violet-soft: rgba(124, 58, 237, 0.12);
+  --shadow-soft: 0 20px 60px rgba(15, 23, 42, 0.06);
+  --shadow-panel: 0 8px 30px rgba(15, 23, 42, 0.04);
+}
 
-/* This file is for your main application CSS */
+[data-theme="dark"] {
+  color-scheme: dark;
+  --page-bg: #0a0c11;
+  --panel-bg: #10131a;
+  --panel-muted: #0d1016;
+  --panel-raised: #141821;
+  --sidebar-bg: #090b10;
+  --sidebar-border: rgba(255, 255, 255, 0.06);
+  --sidebar-link: rgba(255, 255, 255, 0.6);
+  --sidebar-link-active-bg: rgba(255, 255, 255, 0.08);
+  --sidebar-link-active: #ffffff;
+  --border-subtle: rgba(255, 255, 255, 0.08);
+  --border-strong: rgba(255, 255, 255, 0.14);
+  --text-strong: #f4f6fb;
+  --text-muted: #a4adbe;
+  --text-faint: #6f7888;
+  --brand: #f4f6fb;
+  --brand-foreground: #0f1218;
+  --accent: #f59f0b;
+  --accent-soft: rgba(245, 159, 11, 0.16);
+  --session: #22c0dc;
+  --session-soft: rgba(34, 192, 220, 0.14);
+  --success: #22b07d;
+  --success-soft: rgba(34, 176, 125, 0.14);
+  --danger: #fb7185;
+  --danger-soft: rgba(251, 113, 133, 0.14);
+  --violet: #8b5cf6;
+  --violet-soft: rgba(139, 92, 246, 0.16);
+  --shadow-soft: none;
+  --shadow-panel: none;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  background: var(--page-bg);
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background: var(--page-bg);
+  color: var(--text-strong);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  font-feature-settings: "cv11", "ss01";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
+code,
+pre,
+.font-mono {
+  font-family:
+    "JetBrains Mono",
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    "Liberation Mono",
+    monospace;
+}
+
+a,
+button,
+summary,
+select {
+  touch-action: manipulation;
+}
+
+[data-phx-session],
+[data-phx-teleported-src] {
+  display: contents;
+}
+
+.console-shell {
+  min-height: 100vh;
+  background: var(--page-bg);
+}
+
+@media (min-width: 1024px) {
+  .console-shell {
+    display: grid;
+    grid-template-columns: 15rem minmax(0, 1fr);
+  }
+}
+
+.console-sidebar {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  border-right: 1px solid var(--sidebar-border);
+  background: var(--sidebar-bg);
+}
+
+.console-sidebar-inner {
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+  padding: 1rem;
+}
+
+.console-sidebar-footer {
+  margin-top: auto;
+  border-top: 1px solid var(--sidebar-border);
+  padding-top: 1rem;
+}
+
+.console-frame {
+  min-width: 0;
+  min-height: 100vh;
+  padding-bottom: 5.5rem;
+}
+
+@media (min-width: 1024px) {
+  .console-frame {
+    padding-bottom: 0;
+  }
+}
+
+.console-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  display: flex;
+  min-height: 4rem;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--panel-bg);
+  padding: 0 1rem;
+}
+
+@media (min-width: 640px) {
+  .console-topbar {
+    padding: 0 1.5rem;
+  }
+}
+
+.console-page {
+  padding-bottom: 1.5rem;
+}
+
+.console-mobile-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  background: rgba(15, 18, 24, 0.5);
+  backdrop-filter: blur(2px);
+}
+
+.console-mobile-sheet {
+  position: fixed;
+  inset: 0 auto 0 0;
+  z-index: 50;
+  width: min(18rem, 88vw);
+  overflow-y: auto;
+  background: var(--panel-bg);
+  box-shadow: var(--shadow-soft);
+}
+
+.console-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.25rem 0.125rem 1rem;
+  text-decoration: none;
+}
+
+.console-brand-mark {
+  display: inline-flex;
+  height: 2.25rem;
+  width: 2.25rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  background: var(--brand);
+  color: var(--brand-foreground);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+}
+
+.console-brand-label {
+  display: block;
+  color: #ffffff;
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.console-brand-copy {
+  display: block;
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 0.75rem;
+  line-height: 1.25rem;
+}
+
+.console-nav-link,
+.console-mobile-nav-link {
+  display: flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: space-between;
+  border-radius: 8px;
+  color: var(--sidebar-link);
+  padding: 0.75rem 0.875rem;
+  text-decoration: none;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.console-mobile-nav-link {
+  color: var(--text-muted);
+}
+
+.console-nav-link:hover,
+.console-nav-link-active {
+  background: var(--sidebar-link-active-bg);
+  color: var(--sidebar-link-active);
+}
+
+.console-mobile-nav-link:hover,
+.console-mobile-nav-link-active {
+  background: var(--panel-muted);
+  color: var(--text-strong);
+}
+
+.console-nav-count,
+.console-bottom-count {
+  display: inline-flex;
+  min-width: 1.25rem;
+  height: 1.25rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #111827;
+  font-size: 0.625rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0 0.25rem;
+}
+
+.console-bottom-nav {
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 20;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border-top: 1px solid var(--border-subtle);
+  background: var(--panel-bg);
+  padding: 0.375rem 0.5rem calc(0.375rem + env(safe-area-inset-bottom));
+}
+
+@media (min-width: 1024px) {
+  .console-bottom-nav {
+    display: none;
+  }
+}
+
+.console-bottom-link {
+  display: flex;
+  min-height: 52px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  border-radius: 8px;
+  color: var(--text-faint);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.console-bottom-link-active {
+  background: var(--panel-muted);
+  color: var(--text-strong);
+}
+
+.console-bottom-link span.relative {
+  position: relative;
+}
+
+.console-bottom-count {
+  position: absolute;
+  top: -0.375rem;
+  right: -0.75rem;
+}
+
+.console-icon-button {
+  display: inline-flex;
+  min-height: 44px;
+  min-width: 44px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--panel-bg);
+  color: var(--text-muted);
+}
+
+.console-icon-button:hover {
+  border-color: var(--border-strong);
+  color: var(--text-strong);
+}
+
+.console-environment-chip,
+.console-user-chip,
+.console-alert-chip {
+  display: inline-flex;
+  min-height: 36px;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle);
+  background: var(--panel-muted);
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0.5rem 0.875rem;
+  text-decoration: none;
+}
+
+.console-alert-chip {
+  border-color: rgba(245, 159, 11, 0.24);
+  background: var(--accent-soft);
+  color: color-mix(in srgb, var(--accent) 72%, var(--text-strong));
+}
+
+.console-theme-toggle {
+  display: inline-flex;
+  align-items: stretch;
+  gap: 0.25rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--panel-muted);
+  padding: 0.25rem;
+}
+
+.console-theme-option {
+  display: inline-flex;
+  min-height: 36px;
+  align-items: center;
+  gap: 0.375rem;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0 0.75rem;
+}
+
+.console-theme-option:hover {
+  background: var(--panel-bg);
+  color: var(--text-strong);
+}
+
+.console-page-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media (min-width: 640px) {
+  .console-page-header {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+  }
+}
+
+.console-title {
+  font-size: clamp(1.5rem, 1.25rem + 1vw, 2rem);
+  line-height: 1.1;
+  color: var(--text-strong);
+}
+
+.console-copy {
+  color: var(--text-muted);
+  font-size: 0.9375rem;
+  line-height: 1.65;
+}
+
+.console-panel,
+.console-kpi,
+.console-empty,
+.console-code-block {
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--panel-bg);
+  box-shadow: var(--shadow-panel);
+}
+
+.console-panel {
+  padding: 1.25rem;
+}
+
+.console-panel-muted {
+  background: var(--panel-muted);
+}
+
+.console-kpi {
+  padding: 1rem;
+}
+
+.console-kpi-label {
+  color: var(--text-faint);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.console-kpi-value {
+  color: var(--text-strong);
+  font-size: clamp(1.5rem, 1.2rem + 1vw, 2rem);
+  line-height: 1.1;
+  margin: 0.625rem 0 0;
+}
+
+.console-empty {
+  padding: 1.5rem;
+  text-align: center;
+}
+
+.console-list-link,
+.console-list-button {
+  display: block;
+  width: 100%;
+  min-height: 56px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--panel-bg);
+  color: inherit;
+  padding: 1rem;
+  text-align: left;
+  text-decoration: none;
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.console-list-link:hover,
+.console-list-button:hover,
+.console-list-button-selected {
+  background: var(--panel-muted);
+  border-color: var(--border-strong);
+}
+
+.console-list-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.console-list-meta {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+.console-label {
+  color: var(--text-faint);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.375rem;
+  text-transform: uppercase;
+}
+
+.console-value {
+  color: var(--text-strong);
+  font-size: 0.9375rem;
+  line-height: 1.6;
+}
+
+.console-badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+.console-badge-success {
+  background: var(--success-soft);
+  color: var(--success);
+}
+
+.console-badge-warning {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.console-badge-info {
+  background: var(--session-soft);
+  color: var(--session);
+}
+
+.console-badge-neutral {
+  background: rgba(127, 138, 158, 0.12);
+  color: var(--text-muted);
+}
+
+.console-badge-danger {
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+
+.console-badge-violet {
+  background: var(--violet-soft);
+  color: var(--violet);
+}
+
+.console-code-block {
+  overflow-x: auto;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  line-height: 1.7;
+  margin: 0;
+  padding: 1rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.console-tabs {
+  display: flex;
+  gap: 0.375rem;
+  overflow-x: auto;
+  padding-bottom: 0.125rem;
+}
+
+.console-tab {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  gap: 0.5rem;
+  border-bottom: 2px solid transparent;
+  color: var(--text-muted);
+  font-size: 0.875rem;
+  font-weight: 600;
+  padding: 0 0.875rem;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.console-tab:hover,
+.console-tab-active {
+  border-bottom-color: var(--text-strong);
+  color: var(--text-strong);
+}
+
+.console-tab-count {
+  display: inline-flex;
+  min-width: 1.25rem;
+  height: 1.25rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: var(--panel-muted);
+  color: var(--text-muted);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  padding: 0 0.375rem;
+}
+
+.home-preview {
+  width: 100%;
+}
+
+.home-preview-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.home-preview-tab-row {
+  display: flex;
+  gap: 0.25rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.home-preview-tab {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  border-bottom: 2px solid transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0 1rem;
+  transition:
+    color 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.home-preview-tab:hover {
+  color: var(--text-strong);
+}
+
+.home-preview-panels {
+  margin-top: 1rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--panel-bg);
+  box-shadow: var(--shadow-panel);
+  padding: 1.25rem;
+}
+
+.home-preview-panel {
+  display: none;
+}
+
+#home-preview-builder:checked ~ .home-preview-tab-row label[for="home-preview-builder"],
+#home-preview-trace:checked ~ .home-preview-tab-row label[for="home-preview-trace"],
+#home-preview-vault:checked ~ .home-preview-tab-row label[for="home-preview-vault"] {
+  border-bottom-color: var(--text-strong);
+  color: var(--text-strong);
+}
+
+#home-preview-builder:checked ~ .home-preview-panels .home-preview-panel-builder,
+#home-preview-trace:checked ~ .home-preview-panels .home-preview-panel-trace,
+#home-preview-vault:checked ~ .home-preview-panels .home-preview-panel-vault {
+  display: block;
+}
+
+.console-button {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  font-size: 0.875rem;
+  font-weight: 600;
+  padding: 0 1rem;
+  text-decoration: none;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.console-button-primary {
+  background: var(--brand);
+  color: var(--brand-foreground);
+}
+
+.console-button-primary:hover {
+  opacity: 0.92;
+}
+
+.console-button-secondary {
+  background: var(--panel-bg);
+  border-color: var(--border-subtle);
+  color: var(--text-strong);
+}
+
+.console-button-secondary:hover {
+  background: var(--panel-muted);
+  border-color: var(--border-strong);
+}
+
+.console-button-ghost {
+  background: transparent;
+  color: var(--text-muted);
+}
+
+.console-button-ghost:hover {
+  background: var(--panel-muted);
+  color: var(--text-strong);
+}
+
+.console-sm-up-inline-flex,
+.console-md-up-flex,
+.console-md-up-inline-flex,
+.console-lg-up-flex,
+.console-xl-up-inline-flex {
+  display: none;
+}
+
+.console-mobile-only-inline-flex {
+  display: inline-flex;
+}
+
+@media (min-width: 640px) {
+  .console-sm-up-inline-flex {
+    display: inline-flex !important;
+  }
+}
+
+@media (min-width: 768px) {
+  .console-md-up-flex {
+    display: flex !important;
+  }
+
+  .console-md-up-inline-flex {
+    display: inline-flex !important;
+  }
+}
+
+@media (min-width: 1024px) {
+  .console-lg-up-flex {
+    display: flex !important;
+  }
+
+  .console-mobile-only-inline-flex {
+    display: none !important;
+  }
+}
+
+@media (min-width: 1280px) {
+  .console-xl-up-inline-flex {
+    display: inline-flex !important;
+  }
+}
+
+.console-grid-2 {
+  display: grid;
+  gap: 1.25rem;
+}
+
+@media (min-width: 1024px) {
+  .console-grid-2 {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+}
+
+.console-grid-3 {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+@media (min-width: 640px) {
+  .console-grid-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.console-grid-4 {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+@media (min-width: 768px) {
+  .console-grid-4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+.console-field-note {
+  color: var(--text-faint);
+  font-size: 0.75rem;
+  line-height: 1.6;
+  margin-top: 0.5rem;
+}
+
+.console-transcript {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+}
+
+.console-transcript-item {
+  border-radius: 8px;
+  border: 1px solid transparent;
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease;
+}
+
+.console-transcript-item-selected {
+  border-color: var(--border-strong);
+}
+
+.console-composer {
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--panel-bg);
+  box-shadow: var(--shadow-panel);
+  padding: 0.5rem;
+}
+
+.console-composer textarea {
+  width: 100%;
+  min-height: 44px;
+  border: 0;
+  background: transparent;
+  color: var(--text-strong);
+  font: inherit;
+  outline: 0;
+  resize: vertical;
+  padding: 0.5rem 0.625rem;
+}
+
+.console-composer textarea::placeholder {
+  color: var(--text-faint);
+}
+
+.console-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-strong) transparent;
+}
+
+.console-scroll::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+.console-scroll::-webkit-scrollbar-thumb {
+  background: var(--border-strong);
+  border-radius: 999px;
+}

--- a/lib/jido_managed_agents_web.ex
+++ b/lib/jido_managed_agents_web.ex
@@ -88,6 +88,7 @@ defmodule JidoManagedAgentsWeb do
       use DaisyUIComponents, core_components: false
       # Core UI components
       import JidoManagedAgentsWeb.CoreComponents
+      import JidoManagedAgentsWeb.ConsoleComponents
 
       # Common modules used in templates
       alias Phoenix.LiveView.JS

--- a/lib/jido_managed_agents_web/components/console_components.ex
+++ b/lib/jido_managed_agents_web/components/console_components.ex
@@ -1,0 +1,156 @@
+defmodule JidoManagedAgentsWeb.ConsoleComponents do
+  @moduledoc false
+
+  use Phoenix.Component
+
+  import JidoManagedAgentsWeb.CoreComponents
+
+  alias JidoManagedAgentsWeb.ConsoleHelpers
+
+  attr :title, :string, required: true
+  attr :description, :string, default: nil
+  slot :actions
+
+  def page_header(assigns) do
+    ~H"""
+    <div class="console-page-header">
+      <div class="space-y-2">
+        <h1 class="console-title">{@title}</h1>
+        <p :if={@description} class="console-copy max-w-3xl">{@description}</p>
+      </div>
+      <div :if={@actions != []} class="flex flex-wrap gap-3">
+        {render_slot(@actions)}
+      </div>
+    </div>
+    """
+  end
+
+  attr :label, :string, required: true
+  attr :value, :string, required: true
+  attr :icon, :string, default: nil
+  attr :accent, :string, default: nil
+
+  def kpi_card(assigns) do
+    ~H"""
+    <div class="console-kpi">
+      <div class="flex items-center justify-between gap-3">
+        <p class="console-kpi-label">{@label}</p>
+        <.icon
+          :if={@icon}
+          name={@icon}
+          class={["size-4 text-[var(--text-muted)]", @accent]}
+        />
+      </div>
+      <p class={["console-kpi-value", @accent]}>{@value}</p>
+    </div>
+    """
+  end
+
+  attr :status, :any, required: true
+  attr :size, :string, default: "default"
+
+  def status_badge(assigns) do
+    status = normalize_status(assigns.status)
+
+    assigns =
+      assigns
+      |> assign(:label, badge_label(status))
+      |> assign(:badge_class, badge_class(status, assigns.size))
+
+    ~H"""
+    <span class={@badge_class}>{@label}</span>
+    """
+  end
+
+  attr :title, :string, required: true
+  attr :description, :string, default: nil
+  slot :action
+
+  def empty_state(assigns) do
+    ~H"""
+    <div class="console-empty">
+      <div class="space-y-2">
+        <p class="text-sm font-semibold text-[var(--text-strong)]">{@title}</p>
+        <p :if={@description} class="console-copy">{@description}</p>
+      </div>
+      <div :if={@action != []} class="pt-2">
+        {render_slot(@action)}
+      </div>
+    </div>
+    """
+  end
+
+  attr :data, :any, required: true
+  attr :class, :string, default: nil
+
+  def json_block(assigns) do
+    ~H"""
+    <pre class={["console-code-block", @class]}>{ConsoleHelpers.pretty_data(@data)}</pre>
+    """
+  end
+
+  attr :tabs, :list, required: true
+
+  def console_tabs(assigns) do
+    ~H"""
+    <div class="console-tabs">
+      <.link
+        :for={tab <- @tabs}
+        patch={tab[:patch]}
+        navigate={tab[:navigate]}
+        class={["console-tab", tab[:active] && "console-tab-active"]}
+      >
+        {tab.label}
+        <span :if={tab[:count]} class="console-tab-count">{tab.count}</span>
+      </.link>
+    </div>
+    """
+  end
+
+  defp normalize_status(status) when is_atom(status), do: Atom.to_string(status)
+  defp normalize_status(status) when is_binary(status), do: status
+  defp normalize_status(status), do: to_string(status)
+
+  defp badge_label("needs_input"), do: "Needs Input"
+  defp badge_label("mcp_oauth"), do: "OAuth"
+  defp badge_label("static_bearer"), do: "Bearer"
+  defp badge_label("built_in"), do: "Built-in"
+  defp badge_label("always_ask"), do: "Confirm"
+  defp badge_label(status), do: status |> String.replace("_", " ") |> Phoenix.Naming.humanize()
+
+  defp badge_class(status, size) do
+    size_class =
+      case size do
+        "small" -> "px-2 py-1 text-[10px]"
+        _other -> "px-2.5 py-1 text-[11px]"
+      end
+
+    base = "console-badge #{size_class}"
+
+    tone =
+      cond do
+        status in ["active", "completed", "idle"] ->
+          "console-badge-success"
+
+        status in ["needs_input", "confirm", "always_ask", "awaiting_confirmation"] ->
+          "console-badge-warning"
+
+        status in ["running", "mcp", "session", "unrestricted"] ->
+          "console-badge-info"
+
+        status in ["archived", "built_in", "static_bearer", "restricted"] ->
+          "console-badge-neutral"
+
+        status in ["errored", "error", "denied"] ->
+          "console-badge-danger"
+
+        status in ["custom", "resolved"] ->
+          "console-badge-violet"
+
+        true ->
+          "console-badge-neutral"
+      end
+
+    base <> " " <> tone
+  end
+end

--- a/lib/jido_managed_agents_web/components/layouts.ex
+++ b/lib/jido_managed_agents_web/components/layouts.ex
@@ -1,30 +1,12 @@
 defmodule JidoManagedAgentsWeb.Layouts do
   @moduledoc """
-  This module holds layouts and related functionality
-  used by your application.
+  Layouts and shared shell components for the application.
   """
+
   use JidoManagedAgentsWeb, :html
 
-  # Embed all files in layouts/* within this module.
-  # The default root.html.heex file contains the HTML
-  # skeleton of your application, namely HTML headers
-  # and other static content.
   embed_templates "layouts/*"
 
-  @doc """
-  Renders your app layout.
-
-  This function is typically invoked from every template,
-  and it often contains your application menu, sidebar,
-  or similar.
-
-  ## Examples
-
-      <Layouts.app flash={@flash}>
-        <h1>Content</h1>
-      </Layouts.app>
-
-  """
   attr :flash, :map, required: true, doc: "the map of flash messages"
 
   attr :current_scope, :map,
@@ -36,85 +18,151 @@ defmodule JidoManagedAgentsWeb.Layouts do
     doc: "the currently authenticated user"
 
   attr :main_class, :string,
-    default: "px-4 py-20 sm:px-6 lg:px-8",
+    default: "px-4 py-6 sm:px-6 lg:px-8",
     doc: "optional classes for the main wrapper"
 
   attr :container_class, :string,
-    default: "mx-auto max-w-2xl space-y-4",
+    default: "mx-auto max-w-7xl space-y-6",
     doc: "optional classes for the inner content container"
+
+  attr :section, :atom,
+    default: :overview,
+    doc: "the active console section"
+
+  attr :pending_count, :integer,
+    default: 0,
+    doc: "number of sessions awaiting user input"
 
   slot :inner_block, required: true
 
   def app(assigns) do
+    assigns = assign(assigns, :nav_items, console_nav_items())
+
     ~H"""
-    <div class="min-h-screen bg-base-200 text-base-content">
-      <div class="sticky top-0 z-40 border-b border-base-300/80 bg-base-100/90 backdrop-blur">
-        <.navbar class="mx-auto max-w-7xl gap-3 px-3 sm:px-6 lg:px-8">
-          <:navbar_start class="gap-2">
-            <.dropdown class="lg:hidden">
-              <label tabindex="0" class="btn btn-ghost btn-sm btn-circle">
-                <.icon name="hero-bars-3" class="size-5" />
-              </label>
-              <.menu
-                tabindex="0"
-                class="dropdown-content menu-sm z-[60] mt-3 w-56 rounded-box border border-base-300 bg-base-100 p-2 shadow-xl"
-              >
-                <li><.link navigate={~p"/console/agents/new"}>Agents</.link></li>
-                <li><.link navigate={~p"/console/environments"}>Environments</.link></li>
-                <li><.link navigate={~p"/console/vaults"}>Vaults</.link></li>
-                <li><.link navigate={~p"/console/sessions"}>Sessions</.link></li>
-              </.menu>
-            </.dropdown>
+    <div class="console-shell">
+      <aside class="console-sidebar console-lg-up-flex">
+        <div class="console-sidebar-inner">
+          <.console_brand />
 
-            <.link navigate={~p"/console/agents/new"} class="flex items-center gap-3">
-              <span class="flex size-10 items-center justify-center rounded-box bg-primary/12 ring-1 ring-primary/20">
-                <img src={~p"/images/logo.svg"} alt="" class="size-6" />
-              </span>
-              <span class="min-w-0">
-                <span class="block truncate text-sm font-semibold tracking-tight">
-                  Managed Agents
-                </span>
-                <span class="block truncate text-xs text-base-content/60">Runtime console</span>
-              </span>
-            </.link>
-          </:navbar_start>
+          <nav class="space-y-1">
+            <.nav_link
+              :for={item <- @nav_items}
+              item={item}
+              active={item.id == @section}
+              pending_count={@pending_count}
+            />
+          </nav>
 
-          <:navbar_center class="hidden flex-1 lg:flex">
-            <.menu direction="horizontal" class="rounded-box bg-base-200 p-1 text-sm">
-              <li><.link navigate={~p"/console/agents/new"}>Agents</.link></li>
-              <li><.link navigate={~p"/console/environments"}>Environments</.link></li>
-              <li><.link navigate={~p"/console/vaults"}>Vaults</.link></li>
-              <li><.link navigate={~p"/console/sessions"}>Sessions</.link></li>
-            </.menu>
-          </:navbar_center>
+          <div class="console-sidebar-footer">
+            <p class="text-xs font-medium uppercase tracking-[0.2em] text-[var(--text-faint)]">
+              Runtime
+            </p>
+            <p class="mt-2 text-sm leading-6 text-[var(--text-muted)]">
+              Native Phoenix and LiveView console for managed agents, sessions, environments, and vault-backed credentials.
+            </p>
+          </div>
+        </div>
+      </aside>
 
-          <:navbar_end class="gap-2">
-            <span
-              :if={@current_user}
-              class="hidden rounded-full border border-base-300 bg-base-100 px-3 py-1 text-xs font-medium text-base-content/70 md:inline-flex"
+      <div
+        id="console-mobile-backdrop"
+        class="console-mobile-backdrop hidden"
+        phx-click={
+          JS.hide(to: "#console-mobile-backdrop")
+          |> JS.hide(to: "#console-mobile-sheet")
+          |> JS.remove_class("overflow-hidden", to: "body")
+        }
+      />
+
+      <aside id="console-mobile-sheet" class="console-mobile-sheet hidden">
+        <div class="flex items-center justify-between border-b border-[var(--border-subtle)] px-4 py-4">
+          <.console_brand compact />
+
+          <button
+            type="button"
+            class="console-icon-button"
+            phx-click={
+              JS.hide(to: "#console-mobile-backdrop")
+              |> JS.hide(to: "#console-mobile-sheet")
+              |> JS.remove_class("overflow-hidden", to: "body")
+            }
+          >
+            <.icon name="hero-x-mark" class="size-5" />
+          </button>
+        </div>
+
+        <nav class="space-y-1 px-3 py-4">
+          <.mobile_nav_link
+            :for={item <- @nav_items}
+            item={item}
+            active={item.id == @section}
+            pending_count={@pending_count}
+          />
+        </nav>
+      </aside>
+
+      <div class="console-frame">
+        <header class="console-topbar">
+          <div class="flex items-center gap-3">
+            <button
+              type="button"
+              class="console-icon-button console-mobile-only-inline-flex"
+              phx-click={
+                JS.show(to: "#console-mobile-backdrop")
+                |> JS.show(to: "#console-mobile-sheet")
+                |> JS.add_class("overflow-hidden", to: "body")
+              }
             >
+              <.icon name="hero-bars-3" class="size-5" />
+            </button>
+
+            <span class="console-environment-chip console-sm-up-inline-flex">local · v0.1.0</span>
+
+            <.link
+              :if={@pending_count > 0}
+              navigate={~p"/console/sessions"}
+              class="console-alert-chip"
+            >
+              <.icon name="hero-exclamation-circle" class="size-4" />
+              {@pending_count} awaiting input
+            </.link>
+          </div>
+
+          <div class="flex items-center gap-2 sm:gap-3">
+            <div class="console-md-up-flex">
+              <.theme_toggle />
+            </div>
+
+            <span :if={@current_user} class="console-user-chip console-md-up-inline-flex">
               {@current_user.email}
             </span>
-
-            <.theme_toggle />
 
             <.link
               :if={@current_user}
               href={~p"/sign-out"}
               method="delete"
-              class="btn btn-sm btn-ghost"
+              class="console-button console-button-secondary"
             >
               Sign out
             </.link>
-          </:navbar_end>
-        </.navbar>
-      </div>
+          </div>
+        </header>
 
-      <main class={@main_class}>
-        <div class={@container_class}>
-          {render_slot(@inner_block)}
-        </div>
-      </main>
+        <main class={["console-page", @main_class]}>
+          <div class={@container_class}>
+            {render_slot(@inner_block)}
+          </div>
+        </main>
+
+        <nav class="console-bottom-nav">
+          <.bottom_nav_link
+            :for={item <- bottom_nav_items(@nav_items)}
+            item={item}
+            active={item.id == @section}
+            pending_count={@pending_count}
+          />
+        </nav>
+      </div>
 
       <DaisyUIComponents.Flash.flash_group flash={@flash} />
     </div>
@@ -122,39 +170,151 @@ defmodule JidoManagedAgentsWeb.Layouts do
   end
 
   @doc """
-  Provides dark vs light theme toggle based on themes defined in app.css.
-
-  See <head> in root.html.heex which applies the theme before page load.
+  Light, dark, and system theme toggle.
   """
   def theme_toggle(assigns) do
     ~H"""
-    <div class="card relative flex flex-row items-center border-2 border-base-300 bg-base-300 rounded-full">
-      <div class="absolute w-1/3 h-full rounded-full border-1 border-base-200 bg-base-100 brightness-200 left-0 [[data-theme=light]_&]:left-1/3 [[data-theme=dark]_&]:left-2/3 transition-[left]" />
-
+    <div class="console-theme-toggle" role="group" aria-label="Theme">
       <button
-        class="flex p-2 cursor-pointer w-1/3"
+        type="button"
+        class="console-theme-option"
         phx-click={JS.dispatch("phx:set-theme")}
         data-phx-theme="system"
       >
-        <.icon name="hero-computer-desktop-micro" class="size-4 opacity-75 hover:opacity-100" />
+        <.icon name="hero-computer-desktop" class="size-4" />
+        <span>System</span>
       </button>
 
       <button
-        class="flex p-2 cursor-pointer w-1/3"
+        type="button"
+        class="console-theme-option"
         phx-click={JS.dispatch("phx:set-theme")}
         data-phx-theme="light"
       >
-        <.icon name="hero-sun-micro" class="size-4 opacity-75 hover:opacity-100" />
+        <.icon name="hero-sun" class="size-4" />
+        <span>Light</span>
       </button>
 
       <button
-        class="flex p-2 cursor-pointer w-1/3"
+        type="button"
+        class="console-theme-option"
         phx-click={JS.dispatch("phx:set-theme")}
         data-phx-theme="dark"
       >
-        <.icon name="hero-moon-micro" class="size-4 opacity-75 hover:opacity-100" />
+        <.icon name="hero-moon" class="size-4" />
+        <span>Dark</span>
       </button>
     </div>
     """
+  end
+
+  attr :compact, :boolean, default: false
+
+  defp console_brand(assigns) do
+    ~H"""
+    <.link navigate={~p"/console"} class={["console-brand", @compact && "min-w-0"]}>
+      <span class="console-brand-mark">
+        <img src={~p"/images/logo.svg"} alt="" class="size-5" />
+      </span>
+      <span :if={!@compact} class="min-w-0">
+        <span class="console-brand-label">Jido Managed Agents</span>
+        <span class="console-brand-copy">Operator console</span>
+      </span>
+    </.link>
+    """
+  end
+
+  attr :item, :map, required: true
+  attr :active, :boolean, required: true
+  attr :pending_count, :integer, default: 0
+
+  defp nav_link(assigns) do
+    ~H"""
+    <.link navigate={@item.path} class={["console-nav-link", @active && "console-nav-link-active"]}>
+      <span class="flex items-center gap-3">
+        <.icon name={@item.icon} class="size-4 shrink-0" />
+        <span>{@item.label}</span>
+      </span>
+      <span
+        :if={@item.id == :sessions and @pending_count > 0}
+        class="console-nav-count"
+      >
+        {@pending_count}
+      </span>
+    </.link>
+    """
+  end
+
+  attr :item, :map, required: true
+  attr :active, :boolean, required: true
+  attr :pending_count, :integer, default: 0
+
+  defp mobile_nav_link(assigns) do
+    ~H"""
+    <.link
+      navigate={@item.path}
+      class={["console-mobile-nav-link", @active && "console-mobile-nav-link-active"]}
+      phx-click={
+        JS.hide(to: "#console-mobile-backdrop")
+        |> JS.hide(to: "#console-mobile-sheet")
+        |> JS.remove_class("overflow-hidden", to: "body")
+      }
+    >
+      <span class="flex items-center gap-3">
+        <.icon name={@item.icon} class="size-5 shrink-0" />
+        <span>{@item.label}</span>
+      </span>
+      <span
+        :if={@item.id == :sessions and @pending_count > 0}
+        class="console-nav-count"
+      >
+        {@pending_count}
+      </span>
+    </.link>
+    """
+  end
+
+  attr :item, :map, required: true
+  attr :active, :boolean, required: true
+  attr :pending_count, :integer, default: 0
+
+  defp bottom_nav_link(assigns) do
+    ~H"""
+    <.link
+      navigate={@item.path}
+      class={["console-bottom-link", @active && "console-bottom-link-active"]}
+    >
+      <span class="relative">
+        <.icon name={@item.icon} class="size-5" />
+        <span
+          :if={@item.id == :sessions and @pending_count > 0}
+          class="console-bottom-count"
+        >
+          {@pending_count}
+        </span>
+      </span>
+      <span>{@item.label}</span>
+    </.link>
+    """
+  end
+
+  defp console_nav_items do
+    [
+      %{id: :overview, label: "Overview", path: ~p"/console", icon: "hero-squares-2x2"},
+      %{id: :agents, label: "Agents", path: ~p"/console/agents", icon: "hero-cpu-chip"},
+      %{
+        id: :environments,
+        label: "Environments",
+        path: ~p"/console/environments",
+        icon: "hero-server-stack"
+      },
+      %{id: :vaults, label: "Vaults", path: ~p"/console/vaults", icon: "hero-lock-closed"},
+      %{id: :sessions, label: "Sessions", path: ~p"/console/sessions", icon: "hero-bolt"},
+      %{id: :api, label: "API Docs", path: ~p"/console/api-docs", icon: "hero-code-bracket"}
+    ]
+  end
+
+  defp bottom_nav_items(items) do
+    Enum.filter(items, &(&1.id in [:overview, :agents, :sessions, :api]))
   end
 end

--- a/lib/jido_managed_agents_web/controllers/auth_controller.ex
+++ b/lib/jido_managed_agents_web/controllers/auth_controller.ex
@@ -3,7 +3,7 @@ defmodule JidoManagedAgentsWeb.AuthController do
   use AshAuthentication.Phoenix.Controller
 
   def success(conn, activity, user, _token) do
-    return_to = get_session(conn, :return_to) || ~p"/"
+    return_to = get_session(conn, :return_to) || ~p"/console"
 
     message =
       case activity do

--- a/lib/jido_managed_agents_web/controllers/page_html/home.html.heex
+++ b/lib/jido_managed_agents_web/controllers/page_html/home.html.heex
@@ -1,562 +1,260 @@
-<% current_user = assigns[:current_user]
-primary_path = if current_user, do: ~p"/console/agents/new", else: ~p"/sign-in"
-primary_label = if current_user, do: "Launch Console", else: "Sign In"
-secondary_path = if current_user, do: ~p"/console/sessions", else: ~p"/register"
-secondary_label = if current_user, do: "Review Sessions", else: "Create Account" %>
+<div class="flex min-h-screen flex-col bg-[var(--panel-bg)] text-[var(--text-strong)]">
+  <header class="flex min-h-14 items-center justify-between gap-4 border-b border-[var(--border-subtle)] px-4 py-3 sm:px-6">
+    <div class="flex min-w-0 items-center gap-2">
+      <span class="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-[6px] bg-[var(--session)] text-[var(--panel-bg)]">
+        <img src={~p"/images/logo.svg"} alt="" class="size-4" />
+      </span>
+      <span class="truncate text-sm font-semibold text-[var(--text-strong)]">
+        Jido Managed Agents
+      </span>
+      <span class="rounded bg-[var(--panel-muted)] px-2 py-0.5 font-mono text-[10px] text-[var(--text-muted)]">
+        OSS
+      </span>
+    </div>
 
-<DaisyUIComponents.Flash.flash_group flash={@flash} />
+    <div class="flex items-center gap-2">
+      <.link
+        href={~p"/console/api-docs"}
+        class="inline-flex min-h-9 items-center justify-center rounded-[8px] px-3 text-sm font-medium text-[var(--text-muted)] transition hover:text-[var(--text-strong)]"
+      >
+        API Docs
+      </.link>
+      <.link href={~p"/register"} class="console-button console-button-secondary min-h-9 px-3">
+        Create Account
+      </.link>
+      <.link href={~p"/sign-in"} class="console-button console-button-primary min-h-9 px-3">
+        Sign In
+      </.link>
+    </div>
+  </header>
 
-<div class="min-h-screen bg-base-200 text-base-content">
-  <div class="relative isolate overflow-hidden">
-    <div class="absolute inset-x-0 top-0 h-[34rem] bg-gradient-to-b from-primary/12 via-secondary/8 to-transparent" />
-    <div class="absolute -left-20 top-28 size-72 rounded-full bg-secondary/15 blur-3xl" />
-    <div class="absolute -right-16 top-10 size-80 rounded-full bg-primary/20 blur-3xl" />
+  <main class="mx-auto flex w-full max-w-5xl flex-1 flex-col items-center px-6 pb-16 pt-20">
+    <div
+      :for={
+        {kind, message} <- [
+          info: Phoenix.Flash.get(@flash, :info),
+          error: Phoenix.Flash.get(@flash, :error)
+        ]
+      }
+      :if={message}
+      class={[
+        "mb-6 w-full max-w-2xl rounded-[8px] border px-4 py-3 text-sm text-center",
+        kind == :info &&
+          "border-[var(--success)]/20 bg-[var(--success-soft)] text-[var(--text-strong)]",
+        kind == :error &&
+          "border-[var(--danger)]/20 bg-[var(--danger-soft)] text-[var(--text-strong)]"
+      ]}
+    >
+      {message}
+    </div>
 
-    <header class="relative z-10">
-      <div class="mx-auto flex max-w-7xl items-center justify-between gap-4 px-4 py-6 sm:px-6 lg:px-8">
-        <.link
-          href={if current_user, do: ~p"/console/agents/new", else: ~p"/"}
-          class="flex items-center gap-3"
-        >
-          <span class="flex size-11 items-center justify-center rounded-[1.25rem] border border-primary/20 bg-primary/10 shadow-sm shadow-primary/10">
-            <img src={~p"/images/logo.svg"} alt="" class="size-6" />
-          </span>
+    <div class="text-center">
+      <h1 class="text-3xl font-semibold tracking-tight text-[var(--text-strong)] sm:text-4xl">
+        Open-source control plane for managed AI agents
+      </h1>
+      <p class="mx-auto mt-4 max-w-2xl text-sm leading-relaxed text-[var(--text-muted)]">
+        Author versioned agents, attach tools and MCP servers, isolate runtimes with environment templates, manage vault-backed credentials, and replay every session trace — all through a single operator console and an Anthropic-shaped /v1 API.
+      </p>
+    </div>
 
-          <span class="min-w-0">
-            <span class="block truncate text-sm font-semibold tracking-[0.2em] text-base-content/60 uppercase">
-              Managed Agents
-            </span>
-            <span class="block truncate text-base font-semibold tracking-tight">
-              OSS runtime console
-            </span>
-          </span>
-        </.link>
+    <div class="mt-8 flex flex-wrap items-center justify-center gap-3">
+      <.link href={~p"/sign-in"} class="console-button console-button-primary min-h-11 px-5">
+        Sign In <.icon name="hero-arrow-right" class="size-4" />
+      </.link>
+      <.link href={~p"/register"} class="console-button console-button-secondary min-h-11 px-5">
+        Create Account
+      </.link>
+      <.link
+        href={~p"/console/api-docs"}
+        class="inline-flex min-h-11 items-center justify-center rounded-[8px] px-5 text-sm font-medium text-[var(--text-muted)] transition hover:bg-[var(--panel-muted)] hover:text-[var(--text-strong)]"
+      >
+        API Docs
+      </.link>
+    </div>
 
-        <nav class="hidden items-center gap-6 text-sm font-medium text-base-content/65 lg:flex">
-          <a href="#capabilities" class="transition hover:text-base-content">Capabilities</a>
-          <a href="#workflow" class="transition hover:text-base-content">Workflow</a>
-          <a href="#oss" class="transition hover:text-base-content">OSS Surface</a>
-          <.link href={~p"/api/json/swaggerui"} class="transition hover:text-base-content">
-            API
-          </.link>
-        </nav>
+    <div class="mt-6 rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-muted)] px-4 py-2.5 text-xs text-[var(--text-muted)]">
+      <span class="font-medium text-[var(--text-strong)]">Demo account:</span>
+      <code class="ml-1.5 font-mono">demo@example.com</code>
+      <span class="mx-1.5">/</span>
+      <code class="font-mono">demo-pass-1234</code>
+    </div>
 
-        <div class="flex items-center gap-2 sm:gap-3">
-          <Layouts.theme_toggle />
+    <div class="mt-12 w-full max-w-3xl">
+      <div class="home-preview">
+        <input
+          id="home-preview-builder"
+          type="radio"
+          name="home-preview"
+          class="home-preview-input"
+          checked
+        />
+        <input
+          id="home-preview-trace"
+          type="radio"
+          name="home-preview"
+          class="home-preview-input"
+        />
+        <input
+          id="home-preview-vault"
+          type="radio"
+          name="home-preview"
+          class="home-preview-input"
+        />
 
-          <DaisyUIComponents.Button.button
-            :if={!current_user}
-            href={~p"/sign-in"}
-            ghost
-            size="sm"
-            class="hidden sm:inline-flex"
-          >
-            Sign In
-          </DaisyUIComponents.Button.button>
+        <div class="home-preview-tab-row">
+          <label for="home-preview-builder" class="home-preview-tab">Builder</label>
+          <label for="home-preview-trace" class="home-preview-tab">Trace</label>
+          <label for="home-preview-vault" class="home-preview-tab">Vault</label>
+        </div>
 
-          <DaisyUIComponents.Button.button
-            :if={!current_user}
-            href={~p"/register"}
-            color="primary"
-            size="sm"
-          >
-            Create Account
-          </DaisyUIComponents.Button.button>
+        <div class="home-preview-panels">
+          <section class="home-preview-panel home-preview-panel-builder">
+            <div class="space-y-2 text-xs">
+              <div class="flex items-center gap-2 border-b border-[var(--border-subtle)] pb-2">
+                <span class="font-semibold text-[var(--text-strong)]">Coding Assistant</span>
+                <span class="rounded bg-[var(--session-soft)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--session)]">
+                  v3
+                </span>
+              </div>
 
-          <DaisyUIComponents.Button.button
-            :if={current_user}
-            href={~p"/console/agents/new"}
-            color="primary"
-            size="sm"
-          >
-            Console
-          </DaisyUIComponents.Button.button>
+              <div class="space-y-1.5">
+                <div class="flex items-center justify-between gap-3">
+                  <span class="text-[var(--text-muted)]">Model</span>
+                  <span class="font-mono text-[var(--text-strong)]">
+                    claude-sonnet-4-20250514
+                  </span>
+                </div>
+                <div class="flex items-center justify-between gap-3">
+                  <span class="text-[var(--text-muted)]">Tools</span>
+                  <span class="text-[var(--text-strong)]">3 attached</span>
+                </div>
+                <div class="flex items-center justify-between gap-3">
+                  <span class="text-[var(--text-muted)]">MCP Servers</span>
+                  <span class="text-[var(--text-strong)]">1 connected</span>
+                </div>
+                <div class="flex items-center justify-between gap-3">
+                  <span class="text-[var(--text-muted)]">Callable Agents</span>
+                  <span class="text-[var(--text-strong)]">1 linked</span>
+                </div>
+              </div>
 
-          <DaisyUIComponents.Button.button
-            :if={current_user}
-            href={~p"/sign-out"}
-            ghost
-            size="sm"
-            method="delete"
-          >
-            Sign out
-          </DaisyUIComponents.Button.button>
+              <div class="mt-2 rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-muted)] p-2 font-mono text-[10px] text-[var(--text-muted)]">
+                system: "You are a senior software engineer..."
+              </div>
+            </div>
+          </section>
+
+          <section class="home-preview-panel home-preview-panel-trace">
+            <div class="space-y-1.5 text-xs">
+              <div class="flex items-center gap-2 border-b border-[var(--border-subtle)] pb-2">
+                <span class="font-semibold text-[var(--text-strong)]">OSS Happy Path</span>
+                <span class="rounded border border-[var(--session)]/30 bg-[var(--session-soft)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--session)]">
+                  Needs Input
+                </span>
+              </div>
+
+              <div class="flex items-center gap-2 rounded-[8px] bg-[var(--panel-muted)] px-2 py-1">
+                <span class="font-mono text-[10px] text-[var(--text-muted)]">1</span>
+                <span class="rounded bg-[var(--panel-bg)] px-1 py-0.5 font-mono text-[9px] text-[var(--text-muted)]">
+                  user.message
+                </span>
+                <span class="truncate text-[var(--text-strong)]">Fix the login bug</span>
+              </div>
+              <div class="flex items-center gap-2 rounded-[8px] bg-[var(--panel-muted)] px-2 py-1">
+                <span class="font-mono text-[10px] text-[var(--text-muted)]">2</span>
+                <span class="rounded bg-[var(--panel-bg)] px-1 py-0.5 font-mono text-[9px] text-[var(--text-muted)]">
+                  agent.thinking
+                </span>
+                <span class="truncate text-[var(--text-strong)]">Analyzing auth flow...</span>
+              </div>
+              <div class="flex items-center gap-2 rounded-[8px] bg-[var(--panel-muted)] px-2 py-1">
+                <span class="font-mono text-[10px] text-[var(--text-muted)]">3</span>
+                <span class="rounded bg-[var(--panel-bg)] px-1 py-0.5 font-mono text-[9px] text-[var(--text-muted)]">
+                  agent.tool_use
+                </span>
+                <span class="truncate text-[var(--text-strong)]">Reading auth.ts</span>
+              </div>
+              <div class="flex items-center gap-2 rounded-[8px] bg-[var(--panel-muted)] px-2 py-1">
+                <span class="font-mono text-[10px] text-[var(--text-muted)]">4</span>
+                <span class="rounded bg-[var(--panel-bg)] px-1 py-0.5 font-mono text-[9px] text-[var(--text-muted)]">
+                  agent.message
+                </span>
+                <span class="truncate text-[var(--text-strong)]">Found the bug</span>
+              </div>
+              <div class="flex items-center gap-2 rounded-[8px] bg-[var(--panel-muted)] px-2 py-1">
+                <span class="font-mono text-[10px] text-[var(--text-muted)]">5</span>
+                <span class="rounded bg-[var(--panel-bg)] px-1 py-0.5 font-mono text-[9px] text-[var(--text-muted)]">
+                  agent.custom_tool_use
+                </span>
+                <span class="truncate text-[var(--text-strong)]">Awaiting approval</span>
+              </div>
+            </div>
+          </section>
+
+          <section class="home-preview-panel home-preview-panel-vault">
+            <div class="space-y-2 text-xs">
+              <div class="flex items-center gap-2 border-b border-[var(--border-subtle)] pb-2">
+                <.icon name="hero-lock-closed" class="size-3.5 text-[var(--success)]" />
+                <span class="font-semibold text-[var(--text-strong)]">Demo Integrations</span>
+              </div>
+
+              <div class="rounded-[8px] border border-[var(--success)]/20 bg-[var(--success-soft)] p-2 text-[11px] text-[var(--success)]">
+                Secrets are write-only — stored values cannot be retrieved after creation.
+              </div>
+
+              <div class="flex items-center justify-between gap-3 rounded-[8px] bg-[var(--panel-muted)] px-2 py-1.5">
+                <div class="min-w-0">
+                  <span class="font-medium text-[var(--text-strong)]">GitHub MCP Token</span>
+                  <span class="ml-2 font-mono text-[10px] text-[var(--text-muted)]">
+                    static_bearer
+                  </span>
+                </div>
+                <span class="font-mono text-[10px] text-[var(--text-muted)]">
+                  mcp.github.example.com
+                </span>
+              </div>
+
+              <div class="flex items-center justify-between gap-3 rounded-[8px] bg-[var(--panel-muted)] px-2 py-1.5">
+                <div class="min-w-0">
+                  <span class="font-medium text-[var(--text-strong)]">Deploy Pipeline OAuth</span>
+                  <span class="ml-2 font-mono text-[10px] text-[var(--text-muted)]">
+                    mcp_oauth
+                  </span>
+                </div>
+                <span class="font-mono text-[10px] text-[var(--text-muted)]">
+                  mcp.deploy.example.com
+                </span>
+              </div>
+            </div>
+          </section>
         </div>
       </div>
-    </header>
+    </div>
 
-    <main class="relative z-10 pb-20">
-      <section class="mx-auto max-w-7xl px-4 pt-4 sm:px-6 lg:px-8">
-        <.hero class="relative overflow-hidden rounded-[2rem] border border-base-300/80 bg-base-100 shadow-2xl shadow-base-content/5">
-          <:content class="relative z-10 w-full flex-col items-start gap-12 px-6 py-10 sm:px-10 sm:py-12 lg:flex-row lg:items-center lg:px-12 lg:py-16">
-            <div class="max-w-2xl space-y-6">
-              <.badge
-                color="secondary"
-                class="gap-2 border-none bg-secondary/12 px-4 py-3 text-secondary"
-              >
-                <.icon name="hero-command-line" class="size-4" />
-                Open source control plane for agent execution
-              </.badge>
-
-              <div :if={current_user} class="flex flex-wrap items-center gap-3">
-                <.badge
-                  color="success"
-                  class="gap-2 border-none bg-success/12 px-4 py-3 text-success"
-                >
-                  <.icon name="hero-check-circle" class="size-4" />
-                  Signed in as {current_user.email}
-                </.badge>
-              </div>
-
-              <div class="space-y-4">
-                <h1 class="max-w-2xl text-4xl font-semibold leading-tight tracking-tight text-balance sm:text-5xl lg:text-6xl">
-                  Build, run, and inspect managed agents without losing the thread.
-                </h1>
-
-                <p class="max-w-xl text-base leading-8 text-base-content/72 sm:text-lg">
-                  Jido Managed Agents gives you an OSS runtime console for versioned agents,
-                  environment isolation, vault-backed credentials, programmatic APIs, MCP
-                  access, and replayable session traces.
-                </p>
-              </div>
-
-              <div class="flex flex-wrap gap-3 text-sm">
-                <.badge color="info" class="gap-2 border-none bg-info/12 px-4 py-3 text-info">
-                  <.icon name="hero-bolt" class="size-4" /> Session streams
-                </.badge>
-                <.badge
-                  color="warning"
-                  class="gap-2 border-none bg-warning/15 px-4 py-3 text-warning"
-                >
-                  <.icon name="hero-lock-closed" class="size-4" /> Vault isolation
-                </.badge>
-                <.badge
-                  color="accent"
-                  class="gap-2 border-none bg-accent/12 px-4 py-3 text-accent"
-                >
-                  <.icon name="hero-cpu-chip" class="size-4" /> MCP-ready
-                </.badge>
-              </div>
-
-              <div class="flex flex-wrap items-center gap-3">
-                <DaisyUIComponents.Button.button
-                  href={primary_path}
-                  color="primary"
-                  size="lg"
-                  class="shadow-lg shadow-primary/20"
-                >
-                  {primary_label}
-                </DaisyUIComponents.Button.button>
-
-                <DaisyUIComponents.Button.button
-                  href={secondary_path}
-                  size="lg"
-                  ghost
-                  class="border border-base-300"
-                >
-                  {secondary_label}
-                </DaisyUIComponents.Button.button>
-
-                <DaisyUIComponents.Button.button
-                  href={~p"/api/json/swaggerui"}
-                  soft
-                  color="primary"
-                  size="lg"
-                >
-                  API Reference
-                </DaisyUIComponents.Button.button>
-              </div>
-            </div>
-
-            <div class="w-full max-w-xl lg:ml-auto">
-              <div class="grid gap-4">
-                <.card class="border border-base-300/80 bg-base-100/90 shadow-xl shadow-base-content/10 backdrop-blur">
-                  <:card_title class="text-xl">Control plane snapshot</:card_title>
-                  <:card_body class="gap-5">
-                    <p class="text-sm leading-7 text-base-content/68">
-                      Move from agent definition to audited runtime with one surface for authoring,
-                      execution, and post-run inspection.
-                    </p>
-
-                    <div class="rounded-[1.5rem] bg-neutral p-4 font-mono text-xs leading-6 text-neutral-content shadow-inner">
-                      <div class="text-neutral-content/55">session.run</div>
-                      <div>agent: "release-reviewer"</div>
-                      <div>environment: "restricted-demo-sandbox"</div>
-                      <div>vault: "demo-integrations"</div>
-                      <div>trace: streamed + replayable</div>
-                    </div>
-
-                    <div class="grid gap-3 sm:grid-cols-2">
-                      <div class="rounded-[1.25rem] border border-base-300 bg-base-200/60 p-4">
-                        <p class="text-sm font-semibold">Versioned agents</p>
-                        <p class="mt-2 text-sm leading-6 text-base-content/65">
-                          Keep prompts, skills, and tools attached to concrete runtime versions.
-                        </p>
-                      </div>
-
-                      <div class="rounded-[1.25rem] border border-base-300 bg-base-200/60 p-4">
-                        <p class="text-sm font-semibold">Structured traces</p>
-                        <p class="mt-2 text-sm leading-6 text-base-content/65">
-                          Inspect every turn, thread, and event without scraping logs by hand.
-                        </p>
-                      </div>
-                    </div>
-                  </:card_body>
-                </.card>
-
-                <.stats class="w-full border border-base-300/80 bg-base-100 shadow-xl stats-vertical sm:stats-horizontal">
-                  <.stat>
-                    <:title>Authoring</:title>
-                    <:value class="text-3xl">Agents</:value>
-                    <:desc>Versioned definitions, prompts, and tools</:desc>
-                  </.stat>
-
-                  <.stat>
-                    <:title>Runtime</:title>
-                    <:value class="text-3xl">Sessions</:value>
-                    <:desc>Replayable event streams with thread detail</:desc>
-                  </.stat>
-
-                  <.stat>
-                    <:title>Security</:title>
-                    <:value class="text-3xl">Vaults</:value>
-                    <:desc>Scoped credentials with isolation boundaries</:desc>
-                  </.stat>
-                </.stats>
-              </div>
-            </div>
-          </:content>
-
-          <div class="pointer-events-none absolute bottom-0 left-1/3 size-72 rounded-full bg-accent/10 blur-3xl" />
-          <div class="pointer-events-none absolute inset-y-0 right-0 hidden w-1/2 bg-gradient-to-l from-primary/10 via-transparent to-transparent lg:block" />
-        </.hero>
+    <div class="mt-16 grid w-full max-w-3xl grid-cols-1 gap-4 sm:grid-cols-3">
+      <section class="rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-bg)] p-4">
+        <.icon name="hero-cpu-chip" class="size-4 text-[var(--text-muted)]" />
+        <h2 class="mt-2 text-sm font-medium text-[var(--text-strong)]">Agent Authoring</h2>
+        <p class="mt-1 text-xs text-[var(--text-muted)]">
+          Version agents, attach tools, MCP servers, skills, and callable agents.
+        </p>
       </section>
 
-      <section id="capabilities" class="mx-auto mt-24 max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div class="max-w-2xl space-y-4">
-          <.badge color="primary" class="gap-2 border-none bg-primary/10 px-4 py-3 text-primary">
-            <.icon name="hero-squares-2x2" class="size-4" /> Capabilities
-          </.badge>
-
-          <h2 class="text-3xl font-semibold tracking-tight sm:text-4xl">
-            Built for agent systems that need more than a chat box.
-          </h2>
-
-          <p class="text-base leading-8 text-base-content/70 sm:text-lg">
-            The landing surface should explain the product immediately: define agents, lock down
-            execution, and inspect exactly what happened after the run.
-          </p>
-        </div>
-
-        <div class="mt-10 grid gap-6 lg:grid-cols-3">
-          <.card class="border border-base-300 bg-base-100 shadow-xl shadow-base-content/5">
-            <:card_title class="gap-3 text-xl">
-              <span class="flex size-12 items-center justify-center rounded-[1rem] bg-primary/10 text-primary">
-                <.icon name="hero-cpu-chip" class="size-6" />
-              </span>
-              Agent catalog
-            </:card_title>
-            <:card_body class="gap-4">
-              <p class="text-sm leading-7 text-base-content/70">
-                Maintain versioned agents and skills in one place instead of scattering runtime
-                behavior across prompt files and ad hoc scripts.
-              </p>
-
-              <ul class="space-y-3 text-sm text-base-content/68">
-                <li class="flex gap-3">
-                  <.icon name="hero-check" class="mt-0.5 size-4 shrink-0 text-success" />
-                  Builder flow for new agents and editable revisions.
-                </li>
-                <li class="flex gap-3">
-                  <.icon name="hero-check" class="mt-0.5 size-4 shrink-0 text-success" />
-                  Clear separation between catalog data and runtime session state.
-                </li>
-                <li class="flex gap-3">
-                  <.icon name="hero-check" class="mt-0.5 size-4 shrink-0 text-success" />
-                  OSS-first surface that stays compatible with code-driven workflows.
-                </li>
-              </ul>
-            </:card_body>
-            <:card_actions class="justify-start px-6 pb-6">
-              <DaisyUIComponents.Button.button
-                href={primary_path}
-                ghost
-                class="border border-base-300"
-              >
-                Open builder
-              </DaisyUIComponents.Button.button>
-            </:card_actions>
-          </.card>
-
-          <.card class="border border-base-300 bg-base-100 shadow-xl shadow-base-content/5">
-            <:card_title class="gap-3 text-xl">
-              <span class="flex size-12 items-center justify-center rounded-[1rem] bg-warning/12 text-warning">
-                <.icon name="hero-lock-closed" class="size-6" />
-              </span>
-              Secure execution
-            </:card_title>
-            <:card_body class="gap-4">
-              <p class="text-sm leading-7 text-base-content/70">
-                Bind sessions to environments and vault-backed credentials so the runtime boundary
-                is explicit before any tool or model call leaves the process.
-              </p>
-
-              <ul class="space-y-3 text-sm text-base-content/68">
-                <li class="flex gap-3">
-                  <.icon name="hero-check" class="mt-0.5 size-4 shrink-0 text-success" />
-                  Environment registry for allowed tools and execution constraints.
-                </li>
-                <li class="flex gap-3">
-                  <.icon name="hero-check" class="mt-0.5 size-4 shrink-0 text-success" />
-                  Vaults and credentials grouped around practical integration boundaries.
-                </li>
-                <li class="flex gap-3">
-                  <.icon name="hero-check" class="mt-0.5 size-4 shrink-0 text-success" />
-                  API and MCP surfaces for programmatic orchestration outside the browser.
-                </li>
-              </ul>
-            </:card_body>
-            <:card_actions class="justify-start px-6 pb-6">
-              <DaisyUIComponents.Button.button href={~p"/api/json/swaggerui"} soft color="warning">
-                Explore API
-              </DaisyUIComponents.Button.button>
-            </:card_actions>
-          </.card>
-
-          <.card class="border border-base-300 bg-base-100 shadow-xl shadow-base-content/5">
-            <:card_title class="gap-3 text-xl">
-              <span class="flex size-12 items-center justify-center rounded-[1rem] bg-info/12 text-info">
-                <.icon name="hero-signal" class="size-6" />
-              </span>
-              Session observability
-            </:card_title>
-            <:card_body class="gap-4">
-              <p class="text-sm leading-7 text-base-content/70">
-                Treat sessions like first-class runtime artifacts instead of opaque blobs. The UI
-                should make traces, state changes, and failures easy to review under pressure.
-              </p>
-
-              <ul class="space-y-3 text-sm text-base-content/68">
-                <li class="flex gap-3">
-                  <.icon name="hero-check" class="mt-0.5 size-4 shrink-0 text-success" />
-                  Timeline-oriented session detail with thread-aware event streams.
-                </li>
-                <li class="flex gap-3">
-                  <.icon name="hero-check" class="mt-0.5 size-4 shrink-0 text-success" />
-                  Runtime metadata that survives beyond a single browser tab.
-                </li>
-                <li class="flex gap-3">
-                  <.icon name="hero-check" class="mt-0.5 size-4 shrink-0 text-success" />
-                  Designed for real debugging, not just demos.
-                </li>
-              </ul>
-            </:card_body>
-            <:card_actions class="justify-start px-6 pb-6">
-              <DaisyUIComponents.Button.button
-                href={secondary_path}
-                ghost
-                class="border border-base-300"
-              >
-                Inspect sessions
-              </DaisyUIComponents.Button.button>
-            </:card_actions>
-          </.card>
-        </div>
+      <section class="rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-bg)] p-4">
+        <.icon name="hero-bolt" class="size-4 text-[var(--text-muted)]" />
+        <h2 class="mt-2 text-sm font-medium text-[var(--text-strong)]">Session Traces</h2>
+        <p class="mt-1 text-xs text-[var(--text-muted)]">
+          Replay every event — tool calls, thread handoffs, approvals, and errors.
+        </p>
       </section>
 
-      <section id="workflow" class="mx-auto mt-24 max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div class="grid gap-6 lg:grid-cols-[1.15fr_0.85fr]">
-          <.card class="border border-base-300 bg-base-100 shadow-xl shadow-base-content/5">
-            <:card_title class="text-2xl">Define, bind, run, inspect</:card_title>
-            <:card_body class="gap-6">
-              <p class="max-w-2xl text-sm leading-7 text-base-content/70 sm:text-base">
-                The user path should read like an operator workflow, not a framework demo. This
-                sequence maps directly to the core surfaces already in the application.
-              </p>
-
-              <ul class="steps w-full steps-vertical xl:steps-horizontal">
-                <li class="step step-primary">Define agent</li>
-                <li class="step step-primary">Bind environment</li>
-                <li class="step step-primary">Attach vault</li>
-                <li class="step step-primary">Run session</li>
-                <li class="step step-primary">Inspect trace</li>
-              </ul>
-
-              <div class="grid gap-4 md:grid-cols-2">
-                <div class="rounded-[1.25rem] border border-base-300 bg-base-200/60 p-5">
-                  <p class="text-sm font-semibold">API-first by default</p>
-                  <p class="mt-2 text-sm leading-7 text-base-content/65">
-                    Ship through the browser when it is useful, then automate the same surfaces
-                    over the JSON API or the MCP endpoint.
-                  </p>
-                </div>
-
-                <div class="rounded-[1.25rem] border border-base-300 bg-base-200/60 p-5">
-                  <p class="text-sm font-semibold">Operator-friendly review</p>
-                  <p class="mt-2 text-sm leading-7 text-base-content/65">
-                    Sessions stay debuggable because the system preserves event history and thread
-                    context instead of flattening everything into one transcript.
-                  </p>
-                </div>
-              </div>
-            </:card_body>
-          </.card>
-
-          <div id="oss" class="grid gap-4">
-            <.collapse
-              checkbox
-              arrow
-              class="border border-base-300 bg-base-100 shadow-lg shadow-base-content/5"
-            >
-              <:title>
-                <span class="text-base font-semibold">What ships in OSS?</span>
-              </:title>
-              <p class="text-sm leading-7 text-base-content/70">
-                The catalog, environment console, vault and credential management, session
-                persistence, JSON API, and MCP integration surface are all available in the open.
-              </p>
-            </.collapse>
-
-            <.collapse
-              checkbox
-              arrow
-              class="border border-base-300 bg-base-100 shadow-lg shadow-base-content/5"
-            >
-              <:title>
-                <span class="text-base font-semibold">Why a dedicated landing page?</span>
-              </:title>
-              <p class="text-sm leading-7 text-base-content/70">
-                The default Phoenix starter page explains Phoenix. This project needs a homepage
-                that explains managed agents, shows the operator workflow, and points people toward
-                the actual product surfaces.
-              </p>
-            </.collapse>
-
-            <.collapse
-              checkbox
-              arrow
-              class="border border-base-300 bg-base-100 shadow-lg shadow-base-content/5"
-            >
-              <:title>
-                <span class="text-base font-semibold">Where should users go next?</span>
-              </:title>
-              <p class="text-sm leading-7 text-base-content/70">
-                New users should sign in or create an account, then start in the agent builder.
-                Returning users usually want the console or session review immediately.
-              </p>
-            </.collapse>
-
-            <.card class="border border-base-300 bg-base-100 shadow-xl shadow-base-content/5">
-              <:card_title class="text-xl">Start from the real surfaces</:card_title>
-              <:card_body class="gap-4">
-                <p class="text-sm leading-7 text-base-content/70">
-                  Use the browser when you need velocity, then hand the same model over to API or
-                  MCP clients when you need repeatable automation.
-                </p>
-              </:card_body>
-              <:card_actions class="justify-start px-6 pb-6">
-                <DaisyUIComponents.Button.button href={primary_path} color="primary">
-                  Open console
-                </DaisyUIComponents.Button.button>
-                <DaisyUIComponents.Button.button
-                  href={~p"/api/json/swaggerui"}
-                  ghost
-                  class="border border-base-300"
-                >
-                  Swagger UI
-                </DaisyUIComponents.Button.button>
-              </:card_actions>
-            </.card>
-          </div>
-        </div>
+      <section class="rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-bg)] p-4">
+        <.icon name="hero-lock-closed" class="size-4 text-[var(--text-muted)]" />
+        <h2 class="mt-2 text-sm font-medium text-[var(--text-strong)]">Vault Credentials</h2>
+        <p class="mt-1 text-xs text-[var(--text-muted)]">
+          Write-only secrets scoped to MCP server URLs for zero-leak runtime access.
+        </p>
       </section>
-
-      <section class="mx-auto mt-24 max-w-7xl px-4 sm:px-6 lg:px-8">
-        <.footer class="gap-10 rounded-[2rem] border border-base-300 bg-base-100 px-8 py-10 shadow-xl shadow-base-content/5 lg:footer-horizontal">
-          <aside class="max-w-md space-y-4">
-            <div class="flex items-center gap-3">
-              <span class="flex size-11 items-center justify-center rounded-[1.25rem] border border-primary/20 bg-primary/10 shadow-sm shadow-primary/10">
-                <img src={~p"/images/logo.svg"} alt="" class="size-6" />
-              </span>
-              <div>
-                <p class="text-sm font-semibold tracking-[0.2em] text-base-content/60 uppercase">
-                  Managed Agents
-                </p>
-                <p class="text-lg font-semibold tracking-tight">
-                  Open source runtime control plane
-                </p>
-              </div>
-            </div>
-
-            <p class="text-sm leading-7 text-base-content/68">
-              Built for teams that need real runtime boundaries, inspectable sessions, and a UI
-              that explains the product instead of the framework scaffold it started from.
-            </p>
-          </aside>
-
-          <nav class="grid flex-1 gap-8 text-sm sm:grid-cols-3">
-            <div class="space-y-3">
-              <.footer_title>Product</.footer_title>
-              <.link
-                href="#capabilities"
-                class="block text-base-content/70 transition hover:text-base-content"
-              >
-                Capabilities
-              </.link>
-              <.link
-                href="#workflow"
-                class="block text-base-content/70 transition hover:text-base-content"
-              >
-                Workflow
-              </.link>
-              <.link
-                href="#oss"
-                class="block text-base-content/70 transition hover:text-base-content"
-              >
-                OSS Surface
-              </.link>
-            </div>
-
-            <div class="space-y-3">
-              <.footer_title>Console</.footer_title>
-              <.link
-                href={primary_path}
-                class="block text-base-content/70 transition hover:text-base-content"
-              >
-                {primary_label}
-              </.link>
-              <.link
-                href={secondary_path}
-                class="block text-base-content/70 transition hover:text-base-content"
-              >
-                {secondary_label}
-              </.link>
-              <.link
-                href={~p"/api/json/swaggerui"}
-                class="block text-base-content/70 transition hover:text-base-content"
-              >
-                API Reference
-              </.link>
-            </div>
-
-            <div class="space-y-3">
-              <.footer_title>Auth</.footer_title>
-              <.link
-                href={~p"/sign-in"}
-                class="block text-base-content/70 transition hover:text-base-content"
-              >
-                Sign In
-              </.link>
-              <.link
-                href={~p"/register"}
-                class="block text-base-content/70 transition hover:text-base-content"
-              >
-                Create Account
-              </.link>
-            </div>
-          </nav>
-        </.footer>
-      </section>
-    </main>
-  </div>
+    </div>
+  </main>
 </div>

--- a/lib/jido_managed_agents_web/live/agent_builder_live.ex
+++ b/lib/jido_managed_agents_web/live/agent_builder_live.ex
@@ -24,6 +24,7 @@ defmodule JidoManagedAgentsWeb.AgentBuilderLive do
   alias JidoManagedAgents.Sessions.SessionStream
   alias JidoManagedAgents.Sessions.SessionVault
   alias JidoManagedAgents.Sessions.Workspace
+  alias JidoManagedAgentsWeb.ConsoleHelpers
 
   @preview_event_limit 200
 
@@ -52,6 +53,11 @@ defmodule JidoManagedAgentsWeb.AgentBuilderLive do
       |> assign(:runner_task, nil)
       |> assign(:current_session, nil)
       |> assign(:page_title, "New Agent")
+      |> assign(:builder_sections, MapSet.new(["basics"]))
+      |> assign(:preview_tab, "json")
+      |> assign(:preview_expanded, false)
+      |> assign(:show_archive_confirm, false)
+      |> assign(:show_version_history, false)
       |> assign_builder(default_draft())
       |> assign_runner(default_runner_params(environments))
 
@@ -113,6 +119,35 @@ defmodule JidoManagedAgentsWeb.AgentBuilderLive do
   @impl true
   def handle_event("validate_builder", %{"agent" => params}, socket) do
     {:noreply, assign_builder(socket, params)}
+  end
+
+  def handle_event("toggle_builder_section", %{"section" => section}, socket) do
+    sections = socket.assigns.builder_sections
+
+    next_sections =
+      if MapSet.member?(sections, section) do
+        MapSet.delete(sections, section)
+      else
+        MapSet.put(sections, section)
+      end
+
+    {:noreply, assign(socket, :builder_sections, next_sections)}
+  end
+
+  def handle_event("set_preview_tab", %{"tab" => tab}, socket) when tab in ["json", "yaml"] do
+    {:noreply, assign(socket, :preview_tab, tab)}
+  end
+
+  def handle_event("toggle_preview_expanded", _params, socket) do
+    {:noreply, update(socket, :preview_expanded, &(!&1))}
+  end
+
+  def handle_event("toggle_archive_confirm", _params, socket) do
+    {:noreply, update(socket, :show_archive_confirm, &(!&1))}
+  end
+
+  def handle_event("toggle_version_history", _params, socket) do
+    {:noreply, update(socket, :show_version_history, &(!&1))}
   end
 
   def handle_event("add-item", %{"section" => section}, socket) do
@@ -182,6 +217,7 @@ defmodule JidoManagedAgentsWeb.AgentBuilderLive do
         {:noreply,
          socket
          |> assign(:agent, agent)
+         |> assign(:show_archive_confirm, false)
          |> put_flash(:info, "Agent archived.")}
 
       {:error, error} ->
@@ -301,497 +337,580 @@ defmodule JidoManagedAgentsWeb.AgentBuilderLive do
       flash={@flash}
       current_scope={@current_scope}
       current_user={@current_user}
-      main_class="px-4 py-8 sm:px-6 lg:px-8"
-      container_class="mx-auto max-w-7xl space-y-8"
+      section={:agents}
+      main_class="px-4 py-6 sm:px-6 lg:px-8"
+      container_class="mx-auto max-w-7xl space-y-6"
     >
-      <section class="overflow-hidden rounded-[2rem] border border-neutral-200 bg-gradient-to-br from-stone-950 via-neutral-900 to-neutral-800 text-stone-50 shadow-2xl shadow-neutral-950/20">
-        <div class="grid gap-8 px-6 py-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)] lg:px-10">
-          <div class="space-y-4">
-            <p class="text-xs font-semibold uppercase tracking-[0.28em] text-orange-300">
-              Console Builder
-            </p>
-            <h1 class="max-w-3xl text-3xl font-semibold tracking-tight sm:text-4xl">
-              {@page_title}
-            </h1>
-            <p class="max-w-2xl text-sm leading-6 text-stone-300">
-              Shape the agent, inspect the exact request body and YAML, then run a live session against the same workspace without leaving the page.
-            </p>
-          </div>
-          <div class="grid gap-4 rounded-[1.5rem] border border-white/10 bg-white/5 p-5 text-sm text-stone-200 sm:grid-cols-3 lg:grid-cols-1 xl:grid-cols-3">
-            <div>
-              <p class="text-xs uppercase tracking-[0.2em] text-stone-400">Mode</p>
-              <p class="mt-2 font-medium">{if @agent, do: "Edit", else: "Create"}</p>
-            </div>
-            <div>
-              <p class="text-xs uppercase tracking-[0.2em] text-stone-400">Version</p>
-              <p class="mt-2 font-medium">
-                {if @agent, do: @agent.latest_version.version, else: "Draft"}
-              </p>
-            </div>
-            <div>
-              <p class="text-xs uppercase tracking-[0.2em] text-stone-400">Filename</p>
-              <p class="mt-2 font-medium">{@recommended_filename}</p>
-            </div>
-          </div>
-        </div>
-      </section>
+      <.page_header
+        title={if(@agent, do: "Edit: #{@page_title}", else: "New Agent")}
+        description={
+          if @agent,
+            do: "Version #{@agent.latest_version.version} · #{ConsoleHelpers.agent_model(@agent)}",
+            else: "Configure a new agent"
+        }
+      >
+        <:actions>
+          <button
+            :if={@agent}
+            type="button"
+            id="agent-archive-button"
+            phx-click="toggle_archive_confirm"
+            class="console-button console-button-secondary"
+          >
+            Archive
+          </button>
+          <button
+            id="agent-save-button"
+            type="submit"
+            form="agent-builder-form"
+            class="console-button console-button-primary"
+          >
+            {if @agent, do: "Save New Version", else: "Create Agent"}
+          </button>
+        </:actions>
+      </.page_header>
 
-      <div class="grid gap-8 xl:grid-cols-[minmax(0,1.3fr)_minmax(0,0.7fr)]">
-        <div class="space-y-8">
+      <div
+        :if={@show_archive_confirm}
+        class="rounded-[8px] border border-[var(--danger)]/20 bg-[var(--danger-soft)] p-4"
+      >
+        <p class="text-sm font-medium text-[var(--text-strong)]">Archive this agent?</p>
+        <p class="mt-1 text-xs text-[var(--text-muted)]">
+          Archived agents cannot be used in new sessions.
+        </p>
+        <div class="mt-3 flex gap-2">
+          <button
+            type="button"
+            phx-click="archive_agent"
+            class="console-button console-button-primary"
+          >
+            Confirm Archive
+          </button>
+          <button
+            type="button"
+            phx-click="toggle_archive_confirm"
+            class="console-button console-button-secondary"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+
+      <div class="grid gap-6 lg:grid-cols-5">
+        <div class="space-y-3 lg:col-span-3">
           <.form
             for={@builder_form}
             id="agent-builder-form"
             phx-change="validate_builder"
             phx-submit="save_agent"
+            class="space-y-3"
           >
-            <div class="space-y-6 rounded-[2rem] border border-neutral-200 bg-white p-6 shadow-sm">
-              <div class="flex flex-wrap items-center justify-between gap-3">
+            <div
+              :if={@builder_errors != []}
+              id="builder-errors"
+              class="rounded-[8px] border border-[var(--danger)]/20 bg-[var(--danger-soft)] p-4 text-sm text-[var(--text-strong)]"
+            >
+              <p class="font-medium">The current draft has validation issues.</p>
+              <ul class="mt-2 space-y-1">
+                <li :for={error <- @builder_errors}>{error}</li>
+              </ul>
+            </div>
+
+            <section class="rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-bg)]">
+              <button
+                type="button"
+                phx-click="toggle_builder_section"
+                phx-value-section="basics"
+                class="flex w-full items-center justify-between p-4 text-left"
+              >
                 <div>
-                  <h2 class="text-xl font-semibold tracking-tight text-neutral-900">Builder</h2>
-                  <p class="mt-1 text-sm text-neutral-600">
-                    Structured sections keep the draft aligned with the Anthropic-compatible API contract.
+                  <h2 class="text-sm font-semibold text-[var(--text-strong)]">Basics</h2>
+                  <p class="mt-0.5 text-[11px] text-[var(--text-muted)]">
+                    Name, model, and system prompt
                   </p>
                 </div>
-                <div class="flex flex-wrap gap-3">
-                  <.button
-                    id="agent-save-button"
-                    class="rounded-full bg-neutral-900 px-5 text-white hover:bg-neutral-800"
-                  >
-                    {if @agent, do: "Save New Version", else: "Create Agent"}
-                  </.button>
-                  <.button
-                    :if={@agent}
-                    type="button"
-                    id="agent-archive-button"
-                    phx-click="archive_agent"
-                    class="rounded-full border border-neutral-300 bg-white px-5 text-neutral-700 hover:border-neutral-900 hover:text-neutral-900"
-                  >
-                    Archive
-                  </.button>
-                </div>
-              </div>
+                <.icon
+                  name={
+                    if(section_open?(@builder_sections, "basics"),
+                      do: "hero-chevron-down",
+                      else: "hero-chevron-right"
+                    )
+                  }
+                  class="size-4 shrink-0 text-[var(--text-muted)]"
+                />
+              </button>
 
               <div
-                :if={@builder_errors != []}
-                id="builder-errors"
-                class="rounded-2xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-700"
+                :if={section_open?(@builder_sections, "basics")}
+                class="border-t border-[var(--border-subtle)] px-4 pb-4 pt-3"
               >
-                <p class="font-medium">The current draft has validation issues.</p>
-                <ul class="mt-2 space-y-1">
-                  <li :for={error <- @builder_errors}>{error}</li>
-                </ul>
-              </div>
+                <div class="space-y-4">
+                  <div class="grid gap-4 sm:grid-cols-2">
+                    <.input field={@builder_form[:name]} label="Name" placeholder="My Agent" />
+                    <.input
+                      field={@builder_form[:description]}
+                      label="Description"
+                      placeholder="What does this agent do?"
+                    />
+                  </div>
 
-              <section class="grid gap-6 rounded-[1.5rem] border border-neutral-200 bg-neutral-50 p-5 md:grid-cols-2">
-                <div class="md:col-span-2">
-                  <p class="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">
-                    Identity
-                  </p>
-                </div>
-                <.input field={@builder_form[:name]} label="Name" placeholder="Research Coordinator" />
-                <.input
-                  field={@builder_form[:description]}
-                  label="Description"
-                  placeholder="What this agent is responsible for"
-                />
-                <div class="md:col-span-2">
-                  <p class="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">
-                    Model
-                  </p>
-                </div>
-                <.inputs_for :let={model_form} field={@builder_form[:model]}>
-                  <.input field={model_form[:provider]} label="Provider" placeholder="anthropic" />
-                  <.input field={model_form[:id]} label="Model ID" placeholder="claude-sonnet-4-6" />
-                  <.input field={model_form[:speed]} label="Speed" placeholder="standard" />
-                </.inputs_for>
-                <div class="md:col-span-2">
+                  <.inputs_for :let={model_form} field={@builder_form[:model]}>
+                    <div class="grid gap-4 sm:grid-cols-3">
+                      <.input
+                        field={model_form[:provider]}
+                        label="Provider"
+                        placeholder="anthropic"
+                      />
+                      <.input
+                        field={model_form[:id]}
+                        label="Model ID"
+                        placeholder="claude-sonnet-4-20250514"
+                      />
+                      <.input field={model_form[:speed]} label="Speed" placeholder="standard" />
+                    </div>
+                  </.inputs_for>
+
                   <.input
                     field={@builder_form[:system]}
                     type="textarea"
-                    rows="6"
-                    label="System Prompt"
-                    placeholder="You are a precise operator."
-                  />
-                </div>
-                <div class="md:col-span-2">
-                  <.input
-                    field={@builder_form[:metadata_json]}
-                    type="textarea"
                     rows="4"
-                    label="Metadata JSON"
-                    placeholder={~s({"team":"platform"})}
+                    label="System Prompt"
+                    placeholder="You are a helpful agent..."
                   />
                 </div>
-              </section>
+              </div>
+            </section>
 
-              <section class="space-y-4 rounded-[1.5rem] border border-neutral-200 bg-neutral-50 p-5">
-                <div class="flex items-center justify-between gap-3">
-                  <div>
-                    <p class="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">
-                      Tools
-                    </p>
-                    <p class="mt-1 text-sm text-neutral-600">
-                      Built-in toolsets, MCP toolsets, and custom tools.
-                    </p>
-                  </div>
-                  <.button
-                    type="button"
-                    id="add-tool-button"
-                    phx-click="add-item"
-                    phx-value-section="tools"
-                    class="rounded-full border border-neutral-300 bg-white px-4 text-neutral-700 hover:border-neutral-900 hover:text-neutral-900"
-                  >
-                    Add Tool
-                  </.button>
+            <section class="rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-bg)]">
+              <button
+                type="button"
+                phx-click="toggle_builder_section"
+                phx-value-section="capabilities"
+                class="flex w-full items-center justify-between p-4 text-left"
+              >
+                <div>
+                  <h2 class="text-sm font-semibold text-[var(--text-strong)]">Capabilities</h2>
+                  <p class="mt-0.5 text-[11px] text-[var(--text-muted)]">
+                    {length(List.wrap(@draft_params["tools"]))} tools · {length(
+                      List.wrap(@draft_params["mcp_servers"])
+                    )} MCP servers · {length(List.wrap(@draft_params["skills"]))} skills · {length(
+                      List.wrap(@draft_params["callable_agents"])
+                    )} callable agents
+                  </p>
                 </div>
+                <.icon
+                  name={
+                    if(section_open?(@builder_sections, "capabilities"),
+                      do: "hero-chevron-down",
+                      else: "hero-chevron-right"
+                    )
+                  }
+                  class="size-4 shrink-0 text-[var(--text-muted)]"
+                />
+              </button>
 
-                <.inputs_for :let={tool_form} field={@builder_form[:tools]} default={[]}>
-                  <div class="rounded-[1.25rem] border border-neutral-200 bg-white p-4">
-                    <div class="mb-4 flex items-center justify-between gap-3">
-                      <p class="text-sm font-medium text-neutral-900">Tool {tool_form.index + 1}</p>
-                      <button
-                        type="button"
-                        phx-click="remove-item"
-                        phx-value-section="tools"
-                        phx-value-index={tool_form.index}
-                        class="inline-flex items-center gap-2 rounded-full border border-neutral-200 px-3 py-1 text-xs font-medium text-neutral-500 transition hover:border-rose-200 hover:text-rose-600"
-                      >
-                        <.icon name="hero-trash" class="size-4" /> Remove
-                      </button>
-                    </div>
-                    <div class="grid gap-4 md:grid-cols-2">
-                      <.input
-                        field={tool_form[:type]}
-                        type="select"
-                        label="Type"
-                        options={[
-                          {"Built-in Toolset", "agent_toolset_20260401"},
-                          {"MCP Toolset", "mcp_toolset"},
-                          {"Custom Tool", "custom"}
-                        ]}
-                      />
+              <div
+                :if={section_open?(@builder_sections, "capabilities")}
+                class="space-y-4 border-t border-[var(--border-subtle)] px-4 pb-4 pt-3"
+              >
+                <div>
+                  <div class="mb-2 flex items-center justify-between">
+                    <h3 class="text-xs font-medium text-[var(--text-strong)]">Tools</h3>
+                    <button
+                      type="button"
+                      id="add-tool-button"
+                      phx-click="add-item"
+                      phx-value-section="tools"
+                      class="console-button console-button-secondary h-7 px-3 text-xs"
+                    >
+                      <.icon name="hero-plus" class="size-3" /> Add Tool
+                    </button>
+                  </div>
 
-                      <.input
-                        :if={field_value(tool_form[:type]) == "mcp_toolset"}
-                        field={tool_form[:mcp_server_name]}
-                        label="MCP Server Name"
-                        placeholder="docs"
-                      />
+                  <div class="space-y-2">
+                    <.inputs_for :let={tool_form} field={@builder_form[:tools]} default={[]}>
+                      <div class="space-y-2 rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-muted)] p-3">
+                        <div class="flex items-center justify-between">
+                          <div class="flex items-center gap-2">
+                            <.status_badge status={field_value(tool_form[:type])} />
+                            <p class="text-xs font-medium text-[var(--text-strong)]">
+                              Tool {tool_form.index + 1}
+                            </p>
+                          </div>
+                          <button
+                            type="button"
+                            phx-click="remove-item"
+                            phx-value-section="tools"
+                            phx-value-index={tool_form.index}
+                            class="inline-flex h-7 w-7 items-center justify-center rounded-[8px] text-[var(--text-muted)] transition hover:bg-[var(--panel-bg)] hover:text-[var(--text-strong)]"
+                          >
+                            <.icon name="hero-trash" class="size-3.5" />
+                          </button>
+                        </div>
 
-                      <.input
-                        :if={field_value(tool_form[:type]) == "mcp_toolset"}
-                        field={tool_form[:permission_policy]}
-                        type="select"
-                        label="Permission Policy"
-                        options={[
-                          {"Always Ask", "always_ask"},
-                          {"Always Allow", "always_allow"}
-                        ]}
-                      />
+                        <div class="grid gap-2 sm:grid-cols-2">
+                          <.input
+                            field={tool_form[:type]}
+                            type="select"
+                            label="Type"
+                            options={[
+                              {"Built-in Toolset", "agent_toolset_20260401"},
+                              {"MCP Toolset", "mcp_toolset"},
+                              {"Custom Tool", "custom"}
+                            ]}
+                          />
 
-                      <.input
-                        :if={field_value(tool_form[:type]) == "custom"}
-                        field={tool_form[:name]}
-                        label="Tool Name"
-                        placeholder="lookup_release"
-                      />
+                          <.input
+                            :if={field_value(tool_form[:type]) == "mcp_toolset"}
+                            field={tool_form[:mcp_server_name]}
+                            label="MCP Server"
+                            placeholder="server name"
+                          />
 
-                      <.input
-                        :if={field_value(tool_form[:type]) == "custom"}
-                        field={tool_form[:permission_policy]}
-                        type="select"
-                        label="Permission Policy"
-                        options={[
-                          {"Always Ask", "always_ask"},
-                          {"Always Allow", "always_allow"}
-                        ]}
-                      />
+                          <.input
+                            :if={field_value(tool_form[:type]) in ["mcp_toolset", "custom"]}
+                            field={tool_form[:permission_policy]}
+                            type="select"
+                            label="Permission"
+                            options={[
+                              {"Always Ask", "always_ask"},
+                              {"Always Allow", "always_allow"}
+                            ]}
+                          />
 
-                      <div :if={field_value(tool_form[:type]) == "custom"} class="md:col-span-2">
+                          <.input
+                            :if={field_value(tool_form[:type]) == "custom"}
+                            field={tool_form[:name]}
+                            label="Tool Name"
+                            placeholder="lookup_release"
+                          />
+                        </div>
+
                         <.input
+                          :if={field_value(tool_form[:type]) == "custom"}
                           field={tool_form[:description]}
                           label="Description"
                           placeholder="Describe what the tool does"
                         />
-                      </div>
 
-                      <div :if={field_value(tool_form[:type]) == "custom"} class="md:col-span-2">
                         <.input
+                          :if={field_value(tool_form[:type]) == "custom"}
                           field={tool_form[:input_schema_json]}
                           type="textarea"
-                          rows="6"
+                          rows="2"
                           label="Input Schema JSON"
-                          placeholder={~s({"type":"object","properties":{}})}
                         />
-                      </div>
 
-                      <div
-                        :if={field_value(tool_form[:type]) == "agent_toolset_20260401"}
-                        class="md:col-span-2"
-                      >
                         <.input
+                          :if={field_value(tool_form[:type]) == "agent_toolset_20260401"}
                           field={tool_form[:default_config_json]}
                           type="textarea"
-                          rows="4"
-                          label="Default Config JSON"
-                          placeholder={~s({"permission_policy":"always_ask"})}
+                          rows="2"
+                          label="Config JSON"
                         />
-                      </div>
 
-                      <div
-                        :if={field_value(tool_form[:type]) == "agent_toolset_20260401"}
-                        class="md:col-span-2"
-                      >
                         <.input
+                          :if={field_value(tool_form[:type]) == "agent_toolset_20260401"}
                           field={tool_form[:configs_json]}
                           type="textarea"
-                          rows="6"
-                          label="Per-Tool Configs JSON"
-                          placeholder={~s({"write":{"permission_policy":"always_allow"}})}
+                          rows="2"
+                          label="Per-Tool Config JSON"
                         />
                       </div>
-                    </div>
+                    </.inputs_for>
                   </div>
-                </.inputs_for>
-              </section>
-
-              <section class="space-y-4 rounded-[1.5rem] border border-neutral-200 bg-neutral-50 p-5">
-                <div class="flex items-center justify-between gap-3">
-                  <div>
-                    <p class="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">
-                      MCP Servers
-                    </p>
-                    <p class="mt-1 text-sm text-neutral-600">
-                      Server entries persisted on the agent version.
-                    </p>
-                  </div>
-                  <.button
-                    type="button"
-                    id="add-mcp-server-button"
-                    phx-click="add-item"
-                    phx-value-section="mcp_servers"
-                    class="rounded-full border border-neutral-300 bg-white px-4 text-neutral-700 hover:border-neutral-900 hover:text-neutral-900"
-                  >
-                    Add Server
-                  </.button>
                 </div>
 
-                <.inputs_for :let={server_form} field={@builder_form[:mcp_servers]} default={[]}>
-                  <div class="rounded-[1.25rem] border border-neutral-200 bg-white p-4">
-                    <div class="mb-4 flex items-center justify-between gap-3">
-                      <p class="text-sm font-medium text-neutral-900">
-                        Server {server_form.index + 1}
-                      </p>
-                      <button
-                        type="button"
-                        phx-click="remove-item"
-                        phx-value-section="mcp_servers"
-                        phx-value-index={server_form.index}
-                        class="inline-flex items-center gap-2 rounded-full border border-neutral-200 px-3 py-1 text-xs font-medium text-neutral-500 transition hover:border-rose-200 hover:text-rose-600"
-                      >
-                        <.icon name="hero-trash" class="size-4" /> Remove
-                      </button>
-                    </div>
-                    <div class="grid gap-4 md:grid-cols-2">
-                      <.input field={server_form[:type]} label="Type" placeholder="url" />
-                      <.input field={server_form[:name]} label="Name" placeholder="docs" />
-                      <div class="md:col-span-2">
-                        <.input
-                          field={server_form[:url]}
-                          label="URL"
-                          placeholder="https://example.com/mcp"
-                        />
-                      </div>
-                      <div class="md:col-span-2">
-                        <.input
-                          field={server_form[:headers_json]}
-                          type="textarea"
-                          rows="4"
-                          label="Headers JSON"
-                          placeholder={~s({"x-scope":"engineering"})}
-                        />
-                      </div>
-                    </div>
+                <div>
+                  <div class="mb-2 flex items-center justify-between">
+                    <h3 class="text-xs font-medium text-[var(--text-strong)]">MCP Servers</h3>
+                    <button
+                      type="button"
+                      id="add-mcp-server-button"
+                      phx-click="add-item"
+                      phx-value-section="mcp_servers"
+                      class="console-button console-button-secondary h-7 px-3 text-xs"
+                    >
+                      <.icon name="hero-plus" class="size-3" /> Add
+                    </button>
                   </div>
-                </.inputs_for>
-              </section>
 
-              <section class="space-y-4 rounded-[1.5rem] border border-neutral-200 bg-neutral-50 p-5">
-                <div class="flex items-center justify-between gap-3">
-                  <div>
-                    <p class="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">
-                      Skills
-                    </p>
-                    <p class="mt-1 text-sm text-neutral-600">
-                      Attach Anthropic or custom skills from the catalog.
-                    </p>
+                  <div class="space-y-2">
+                    <div
+                      :if={List.wrap(@draft_params["mcp_servers"]) == []}
+                      class="text-xs text-[var(--text-muted)]"
+                    >
+                      No MCP servers configured.
+                    </div>
+
+                    <.inputs_for :let={server_form} field={@builder_form[:mcp_servers]} default={[]}>
+                      <div class="space-y-2 rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-muted)] p-3">
+                        <div class="flex items-center justify-between">
+                          <.input
+                            field={server_form[:name]}
+                            label="Name"
+                            placeholder="Server name"
+                          />
+                          <button
+                            type="button"
+                            phx-click="remove-item"
+                            phx-value-section="mcp_servers"
+                            phx-value-index={server_form.index}
+                            class="mt-6 inline-flex h-7 w-7 items-center justify-center rounded-[8px] text-[var(--text-muted)] transition hover:bg-[var(--panel-bg)] hover:text-[var(--text-strong)]"
+                          >
+                            <.icon name="hero-trash" class="size-3.5" />
+                          </button>
+                        </div>
+                        <.input field={server_form[:url]} label="URL" placeholder="https://..." />
+                      </div>
+                    </.inputs_for>
                   </div>
-                  <.button
-                    type="button"
-                    id="add-skill-button"
-                    phx-click="add-item"
-                    phx-value-section="skills"
-                    class="rounded-full border border-neutral-300 bg-white px-4 text-neutral-700 hover:border-neutral-900 hover:text-neutral-900"
-                  >
-                    Add Skill
-                  </.button>
                 </div>
 
-                <.inputs_for :let={skill_form} field={@builder_form[:skills]} default={[]}>
-                  <div class="rounded-[1.25rem] border border-neutral-200 bg-white p-4">
-                    <div class="mb-4 flex items-center justify-between gap-3">
-                      <p class="text-sm font-medium text-neutral-900">Skill {skill_form.index + 1}</p>
-                      <button
-                        type="button"
-                        phx-click="remove-item"
-                        phx-value-section="skills"
-                        phx-value-index={skill_form.index}
-                        class="inline-flex items-center gap-2 rounded-full border border-neutral-200 px-3 py-1 text-xs font-medium text-neutral-500 transition hover:border-rose-200 hover:text-rose-600"
-                      >
-                        <.icon name="hero-trash" class="size-4" /> Remove
-                      </button>
-                    </div>
-                    <div class="grid gap-4 md:grid-cols-2">
-                      <.input
-                        field={skill_form[:type]}
-                        type="select"
-                        label="Skill Type"
-                        options={[{"Custom", "custom"}, {"Anthropic", "anthropic"}]}
-                      />
-                      <.input
-                        field={skill_form[:id]}
-                        type="select"
-                        label="Skill"
-                        options={skill_options(@skills)}
-                      />
-                      <.input
-                        field={skill_form[:version]}
-                        type="number"
-                        min="1"
-                        label="Pinned Version"
-                        placeholder="Latest"
-                      />
-                      <div class="md:col-span-2">
-                        <.input
-                          field={skill_form[:metadata_json]}
-                          type="textarea"
-                          rows="4"
-                          label="Metadata JSON"
-                          placeholder={~s({"audience":"platform"})}
-                        />
-                      </div>
-                    </div>
+                <div>
+                  <div class="mb-2 flex items-center justify-between">
+                    <h3 class="text-xs font-medium text-[var(--text-strong)]">Skills</h3>
+                    <button
+                      type="button"
+                      id="add-skill-button"
+                      phx-click="add-item"
+                      phx-value-section="skills"
+                      class="console-button console-button-secondary h-7 px-3 text-xs"
+                    >
+                      <.icon name="hero-plus" class="size-3" /> Add
+                    </button>
                   </div>
-                </.inputs_for>
-              </section>
 
-              <section class="space-y-4 rounded-[1.5rem] border border-neutral-200 bg-neutral-50 p-5">
-                <div class="flex items-center justify-between gap-3">
-                  <div>
-                    <p class="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">
-                      Callable Agents
-                    </p>
-                    <p class="mt-1 text-sm text-neutral-600">
-                      Delegate to other persisted agents in the same session tree.
-                    </p>
+                  <div class="space-y-2">
+                    <div
+                      :if={List.wrap(@draft_params["skills"]) == []}
+                      class="text-xs text-[var(--text-muted)]"
+                    >
+                      No skills attached.
+                    </div>
+
+                    <.inputs_for :let={skill_form} field={@builder_form[:skills]} default={[]}>
+                      <div class="flex items-center gap-2 rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-muted)] p-2">
+                        <.input
+                          field={skill_form[:type]}
+                          type="select"
+                          label="Type"
+                          options={[{"Custom", "custom"}, {"Anthropic", "anthropic"}]}
+                        />
+                        <.input
+                          field={skill_form[:id]}
+                          type="select"
+                          label="Skill"
+                          options={skill_options(@skills)}
+                        />
+                        <.input
+                          field={skill_form[:version]}
+                          type="number"
+                          min="1"
+                          label="v"
+                          placeholder="Latest"
+                        />
+                        <button
+                          type="button"
+                          phx-click="remove-item"
+                          phx-value-section="skills"
+                          phx-value-index={skill_form.index}
+                          class="mt-6 inline-flex h-7 w-7 items-center justify-center rounded-[8px] text-[var(--text-muted)] transition hover:bg-[var(--panel-bg)] hover:text-[var(--text-strong)]"
+                        >
+                          <.icon name="hero-trash" class="size-3.5" />
+                        </button>
+                      </div>
+                    </.inputs_for>
                   </div>
-                  <.button
-                    type="button"
-                    id="add-callable-agent-button"
-                    phx-click="add-item"
-                    phx-value-section="callable_agents"
-                    class="rounded-full border border-neutral-300 bg-white px-4 text-neutral-700 hover:border-neutral-900 hover:text-neutral-900"
-                  >
-                    Add Callable Agent
-                  </.button>
                 </div>
 
-                <.inputs_for
-                  :let={callable_form}
-                  field={@builder_form[:callable_agents]}
-                  default={[]}
-                >
-                  <div class="rounded-[1.25rem] border border-neutral-200 bg-white p-4">
-                    <div class="mb-4 flex items-center justify-between gap-3">
-                      <p class="text-sm font-medium text-neutral-900">
-                        Callable Agent {callable_form.index + 1}
-                      </p>
+                <div>
+                  <div class="mb-2 flex items-center justify-between">
+                    <h3 class="text-xs font-medium text-[var(--text-strong)]">Callable Agents</h3>
+                    <button
+                      type="button"
+                      id="add-callable-agent-button"
+                      phx-click="add-item"
+                      phx-value-section="callable_agents"
+                      class="console-button console-button-secondary h-7 px-3 text-xs"
+                    >
+                      <.icon name="hero-plus" class="size-3" /> Add
+                    </button>
+                  </div>
+
+                  <div class="space-y-2">
+                    <div
+                      :if={List.wrap(@draft_params["callable_agents"]) == []}
+                      class="text-xs text-[var(--text-muted)]"
+                    >
+                      No callable agents linked.
+                    </div>
+
+                    <.inputs_for
+                      :let={callable_form}
+                      field={@builder_form[:callable_agents]}
+                      default={[]}
+                    >
+                      <div class="flex items-center gap-2 rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-muted)] p-2">
+                        <.input
+                          field={callable_form[:id]}
+                          type="select"
+                          label="Agent"
+                          options={callable_agent_options(@callable_agents, @agent)}
+                        />
+                        <.input
+                          field={callable_form[:version]}
+                          type="number"
+                          min="1"
+                          label="v"
+                          placeholder="Latest"
+                        />
+                        <button
+                          type="button"
+                          phx-click="remove-item"
+                          phx-value-section="callable_agents"
+                          phx-value-index={callable_form.index}
+                          class="mt-6 inline-flex h-7 w-7 items-center justify-center rounded-[8px] text-[var(--text-muted)] transition hover:bg-[var(--panel-bg)] hover:text-[var(--text-strong)]"
+                        >
+                          <.icon name="hero-trash" class="size-3.5" />
+                        </button>
+                      </div>
+                    </.inputs_for>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <section class="rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-bg)]">
+              <button
+                type="button"
+                phx-click="toggle_builder_section"
+                phx-value-section="advanced"
+                class="flex w-full items-center justify-between p-4 text-left"
+              >
+                <div>
+                  <h2 class="text-sm font-semibold text-[var(--text-strong)]">Advanced</h2>
+                  <p class="mt-0.5 text-[11px] text-[var(--text-muted)]">
+                    Metadata and API preview
+                  </p>
+                </div>
+                <.icon
+                  name={
+                    if(section_open?(@builder_sections, "advanced"),
+                      do: "hero-chevron-down",
+                      else: "hero-chevron-right"
+                    )
+                  }
+                  class="size-4 shrink-0 text-[var(--text-muted)]"
+                />
+              </button>
+
+              <div
+                :if={section_open?(@builder_sections, "advanced")}
+                class="space-y-4 border-t border-[var(--border-subtle)] px-4 pb-4 pt-3"
+              >
+                <.input
+                  field={@builder_form[:metadata_json]}
+                  type="textarea"
+                  rows="3"
+                  label="Metadata JSON"
+                />
+
+                <p class="text-[10px] text-[var(--text-muted)]">
+                  Recommended filename: <code class="font-mono">{@recommended_filename}</code>
+                </p>
+
+                <div class="lg:hidden">
+                  <div class="mb-2 flex items-center justify-between">
+                    <div class="flex gap-1">
                       <button
                         type="button"
-                        phx-click="remove-item"
-                        phx-value-section="callable_agents"
-                        phx-value-index={callable_form.index}
-                        class="inline-flex items-center gap-2 rounded-full border border-neutral-200 px-3 py-1 text-xs font-medium text-neutral-500 transition hover:border-rose-200 hover:text-rose-600"
+                        phx-click="set_preview_tab"
+                        phx-value-tab="json"
+                        class={[
+                          "rounded px-2 py-1 text-xs font-medium",
+                          @preview_tab == "json" && "bg-[var(--text-strong)] text-[var(--panel-bg)]",
+                          @preview_tab != "json" && "text-[var(--text-muted)]"
+                        ]}
                       >
-                        <.icon name="hero-trash" class="size-4" /> Remove
+                        JSON
+                      </button>
+                      <button
+                        type="button"
+                        phx-click="set_preview_tab"
+                        phx-value-tab="yaml"
+                        class={[
+                          "rounded px-2 py-1 text-xs font-medium",
+                          @preview_tab == "yaml" && "bg-[var(--text-strong)] text-[var(--panel-bg)]",
+                          @preview_tab != "yaml" && "text-[var(--text-muted)]"
+                        ]}
+                      >
+                        YAML
                       </button>
                     </div>
-                    <div class="grid gap-4 md:grid-cols-2">
-                      <.input
-                        field={callable_form[:id]}
-                        type="select"
-                        label="Agent"
-                        options={callable_agent_options(@callable_agents, @agent)}
-                      />
-                      <.input
-                        field={callable_form[:version]}
-                        type="number"
-                        min="1"
-                        label="Pinned Version"
-                        placeholder="Latest"
-                      />
-                      <div class="md:col-span-2">
-                        <.input
-                          field={callable_form[:metadata_json]}
-                          type="textarea"
-                          rows="4"
-                          label="Metadata JSON"
-                          placeholder={~s({"handoff":"research"})}
-                        />
-                      </div>
-                    </div>
                   </div>
-                </.inputs_for>
-              </section>
-            </div>
+
+                  <pre
+                    :if={@preview_tab == "json"}
+                    class="console-code-block max-h-[300px] overflow-auto"
+                  ><code>{@api_preview}</code></pre>
+                  <pre
+                    :if={@preview_tab == "yaml"}
+                    class="console-code-block max-h-[300px] overflow-auto"
+                  ><code>{@yaml_preview}</code></pre>
+                </div>
+              </div>
+            </section>
           </.form>
 
-          <section class="space-y-4 rounded-[2rem] border border-neutral-200 bg-white p-6 shadow-sm">
-            <div class="flex flex-wrap items-center justify-between gap-3">
-              <div>
-                <h2 class="text-xl font-semibold tracking-tight text-neutral-900">Session Runner</h2>
-                <p class="mt-1 text-sm text-neutral-600">
-                  The runner uses the agent workspace automatically and keeps the event stream inline.
-                </p>
-              </div>
-              <div
-                :if={@runner_status}
-                class="rounded-full bg-neutral-900 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-white"
-              >
-                {@runner_status}
-              </div>
-            </div>
-
-            <.form
-              for={@runner_form}
-              id="agent-runner-form"
-              phx-change="validate_runner"
-              phx-submit="launch_session"
+          <section class="rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-bg)]">
+            <button
+              type="button"
+              phx-click="toggle_builder_section"
+              phx-value-section="testrun"
+              class="flex w-full items-center justify-between p-4 text-left"
             >
-              <div class="grid gap-4 md:grid-cols-2">
-                <.input
-                  field={@runner_form[:environment_id]}
-                  type="select"
-                  label="Environment"
-                  prompt="Choose an environment"
-                  options={environment_options(@environments)}
-                />
-                <.input
-                  field={@runner_form[:title]}
-                  label="Session Title"
-                  placeholder="Optional title"
-                />
-                <div class="md:col-span-2">
+              <div>
+                <h2 class="text-sm font-semibold text-[var(--text-strong)]">Test Run</h2>
+                <p class="mt-0.5 text-[11px] text-[var(--text-muted)]">Launch a test session</p>
+              </div>
+              <.icon
+                name={
+                  if(section_open?(@builder_sections, "testrun"),
+                    do: "hero-chevron-down",
+                    else: "hero-chevron-right"
+                  )
+                }
+                class="size-4 shrink-0 text-[var(--text-muted)]"
+              />
+            </button>
+
+            <div
+              :if={section_open?(@builder_sections, "testrun")}
+              class="space-y-4 border-t border-[var(--border-subtle)] px-4 pb-4 pt-3"
+            >
+              <.form
+                for={@runner_form}
+                id="agent-runner-form"
+                phx-change="validate_runner"
+                phx-submit="launch_session"
+              >
+                <div class="space-y-3">
+                  <div class="grid gap-3 sm:grid-cols-2">
+                    <.input
+                      field={@runner_form[:environment_id]}
+                      type="select"
+                      label="Environment"
+                      prompt="Select environment"
+                      options={environment_options(@environments)}
+                    />
+                    <.input
+                      field={@runner_form[:title]}
+                      label="Session Title"
+                      placeholder="Optional title"
+                    />
+                  </div>
+
                   <.input
                     field={@runner_form[:vault_ids]}
                     type="select"
@@ -799,134 +918,180 @@ defmodule JidoManagedAgentsWeb.AgentBuilderLive do
                     label="Vaults"
                     options={vault_options(@vaults)}
                   />
-                </div>
-                <div class="md:col-span-2">
+
                   <.input
                     field={@runner_form[:prompt]}
                     type="textarea"
-                    rows="5"
+                    rows="3"
                     label="Prompt"
-                    placeholder="Ask the agent to perform a real test run."
+                    placeholder="Enter your prompt..."
                   />
-                </div>
-              </div>
-              <div class="mt-4 flex flex-wrap items-center gap-3">
-                <.button
-                  id="runner-submit-button"
-                  class="rounded-full bg-orange-500 px-5 text-white hover:bg-orange-400"
-                >
-                  {if @current_session, do: "Send To Current Session", else: "Launch Session"}
-                </.button>
-                <p class="text-xs text-neutral-500">
-                  Workspace selection is automatic in v1 and tied to the agent.
-                </p>
-              </div>
-            </.form>
 
-            <div
-              :if={@runner_error}
-              id="runner-error"
-              class="rounded-2xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-700"
-            >
-              {@runner_error}
-            </div>
-
-            <div
-              :if={@runner_notice}
-              id="runner-notice"
-              class="rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800"
-            >
-              {@runner_notice}
-            </div>
-
-            <div id="runner-events" class="space-y-3">
-              <div
-                :if={@runner_events == []}
-                class="rounded-[1.5rem] border border-dashed border-neutral-300 bg-neutral-50 px-4 py-10 text-center text-sm text-neutral-500"
-              >
-                Session events will stream here after you start a run.
-              </div>
-
-              <div
-                :for={event <- @runner_events}
-                id={"runner-event-#{event.sequence}"}
-                class="rounded-[1.5rem] border border-neutral-200 bg-neutral-950 px-4 py-4 text-sm text-stone-100 shadow-sm"
-              >
-                <div class="flex flex-wrap items-center justify-between gap-3">
-                  <div class="flex items-center gap-2">
-                    <span class="rounded-full bg-white/10 px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-300">
-                      {event.type}
-                    </span>
-                    <span class="font-mono text-xs text-stone-400">#{event.sequence}</span>
+                  <div class="flex items-center gap-3">
+                    <.button id="runner-submit-button" class="console-button console-button-primary">
+                      {if @current_session, do: "Send To Current Session", else: "Launch Session"}
+                    </.button>
+                    <p :if={@runner_status} class="text-xs text-[var(--text-muted)]">
+                      {@runner_status}
+                    </p>
                   </div>
-                  <span class="text-xs text-stone-500">{format_timestamp(event.created_at)}</span>
                 </div>
-                <p class="mt-3 whitespace-pre-wrap font-mono text-[13px] leading-6 text-stone-100">
-                  {event_console_body(event)}
-                </p>
+              </.form>
+
+              <div
+                :if={@runner_error}
+                id="runner-error"
+                class="rounded-[8px] border border-[var(--danger)]/20 bg-[var(--danger-soft)] p-4 text-sm text-[var(--text-strong)]"
+              >
+                {@runner_error}
+              </div>
+
+              <div
+                :if={@runner_notice}
+                id="runner-notice"
+                class="rounded-[8px] border border-[var(--accent)]/20 bg-[var(--accent-soft)] p-4 text-sm text-[var(--text-strong)]"
+              >
+                {@runner_notice}
+              </div>
+
+              <div id="runner-events" class="space-y-2">
+                <div
+                  :if={@runner_events == []}
+                  class="rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-muted)] px-4 py-10 text-center text-sm text-[var(--text-muted)]"
+                >
+                  Session events will stream here after you start a run.
+                </div>
+
+                <div
+                  :for={event <- @runner_events}
+                  id={"runner-event-#{event.sequence}"}
+                  class="rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-muted)] p-4"
+                >
+                  <div class="flex items-center justify-between gap-3">
+                    <div class="flex items-center gap-2">
+                      <span class="console-badge console-badge-neutral px-2 py-1 text-[10px]">
+                        {event.type}
+                      </span>
+                      <span class="font-mono text-[10px] text-[var(--text-muted)]">
+                        #{event.sequence}
+                      </span>
+                    </div>
+                    <span class="text-[10px] text-[var(--text-muted)]">
+                      {format_timestamp(event.created_at)}
+                    </span>
+                  </div>
+                  <p class="mt-2 whitespace-pre-wrap font-mono text-xs text-[var(--text-strong)]">
+                    {event_console_body(event)}
+                  </p>
+                </div>
               </div>
             </div>
           </section>
         </div>
 
-        <div class="space-y-8">
-          <section class="space-y-4 rounded-[2rem] border border-neutral-200 bg-white p-6 shadow-sm">
-            <div class="flex items-center justify-between gap-3">
-              <div>
-                <h2 class="text-xl font-semibold tracking-tight text-neutral-900">API Preview</h2>
-                <p class="mt-1 text-sm text-neutral-600">
-                  The equivalent request body for the current draft.
-                </p>
-              </div>
-              <span class="rounded-full bg-neutral-100 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-neutral-500">
-                JSON
-              </span>
-            </div>
-            <pre
-              id="api-preview"
-              class="overflow-x-auto rounded-[1.5rem] bg-neutral-950 p-4 text-[13px] leading-6 text-stone-100"
-            ><code>{@api_preview}</code></pre>
-          </section>
-
-          <section class="space-y-4 rounded-[2rem] border border-neutral-200 bg-white p-6 shadow-sm">
-            <div class="flex items-center justify-between gap-3">
-              <div>
-                <h2 class="text-xl font-semibold tracking-tight text-neutral-900">YAML Preview</h2>
-                <p class="mt-1 text-sm text-neutral-600">
-                  Anthropic-compatible `*.agent.yaml` output for the same draft.
-                </p>
-              </div>
-              <span class="rounded-full bg-neutral-100 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-neutral-500">
-                YAML
-              </span>
-            </div>
-            <pre
-              id="yaml-preview"
-              class="overflow-x-auto rounded-[1.5rem] bg-[#10111a] p-4 text-[13px] leading-6 text-emerald-100"
-            ><code>{@yaml_preview}</code></pre>
-          </section>
-
-          <section
-            :if={@versions != []}
-            class="space-y-4 rounded-[2rem] border border-neutral-200 bg-white p-6 shadow-sm"
-          >
-            <div>
-              <h2 class="text-xl font-semibold tracking-tight text-neutral-900">Versions</h2>
-              <p class="mt-1 text-sm text-neutral-600">Recent persisted versions for this agent.</p>
-            </div>
-            <div id="version-list" class="space-y-3">
-              <div
-                :for={version <- @versions}
-                class="rounded-[1.25rem] border border-neutral-200 bg-neutral-50 px-4 py-3"
+        <div class="hidden lg:block lg:col-span-2">
+          <div class="sticky top-20 space-y-3">
+            <section class="rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-bg)]">
+              <button
+                type="button"
+                phx-click="toggle_preview_expanded"
+                class="flex w-full items-center justify-between px-4 py-2.5 text-sm font-medium text-[var(--text-strong)]"
               >
-                <div class="flex items-center justify-between gap-3">
-                  <p class="font-medium text-neutral-900">Version {version.version}</p>
-                  <span class="text-xs text-neutral-500">{format_timestamp(version.updated_at)}</span>
+                API Preview
+                <.icon
+                  name={if(@preview_expanded, do: "hero-chevron-down", else: "hero-chevron-right")}
+                  class="size-4 text-[var(--text-muted)]"
+                />
+              </button>
+
+              <div :if={@preview_expanded} class="border-t border-[var(--border-subtle)]">
+                <div class="flex items-center justify-between px-4 py-2">
+                  <div class="flex gap-1">
+                    <button
+                      type="button"
+                      phx-click="set_preview_tab"
+                      phx-value-tab="json"
+                      class={[
+                        "rounded px-2 py-1 text-xs font-medium",
+                        @preview_tab == "json" && "bg-[var(--text-strong)] text-[var(--panel-bg)]",
+                        @preview_tab != "json" && "text-[var(--text-muted)]"
+                      ]}
+                    >
+                      JSON
+                    </button>
+                    <button
+                      type="button"
+                      phx-click="set_preview_tab"
+                      phx-value-tab="yaml"
+                      class={[
+                        "rounded px-2 py-1 text-xs font-medium",
+                        @preview_tab == "yaml" && "bg-[var(--text-strong)] text-[var(--panel-bg)]",
+                        @preview_tab != "yaml" && "text-[var(--text-muted)]"
+                      ]}
+                    >
+                      YAML
+                    </button>
+                  </div>
                 </div>
-                <p class="mt-1 text-sm text-neutral-600">{version.name}</p>
+
+                <div class="px-4 pb-3">
+                  <pre
+                    id="api-preview"
+                    class={[
+                      "console-code-block max-h-[400px] overflow-auto",
+                      @preview_tab != "json" && "hidden"
+                    ]}
+                  ><code>{@api_preview}</code></pre>
+                  <pre
+                    id="yaml-preview"
+                    class={[
+                      "console-code-block max-h-[400px] overflow-auto",
+                      @preview_tab != "yaml" && "hidden"
+                    ]}
+                  ><code>{@yaml_preview}</code></pre>
+                </div>
+
+                <div class="border-t border-[var(--border-subtle)] px-4 py-2">
+                  <p class="text-[10px] text-[var(--text-muted)]">
+                    Recommended filename: <code class="font-mono">{@recommended_filename}</code>
+                  </p>
+                </div>
               </div>
-            </div>
-          </section>
+            </section>
+
+            <section
+              :if={@versions != []}
+              class="rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-bg)] p-4"
+            >
+              <button
+                type="button"
+                phx-click="toggle_version_history"
+                class="flex w-full items-center justify-between text-sm font-medium text-[var(--text-strong)]"
+              >
+                Version History
+                <.icon
+                  name={
+                    if(@show_version_history, do: "hero-chevron-down", else: "hero-chevron-right")
+                  }
+                  class="size-4 text-[var(--text-muted)]"
+                />
+              </button>
+
+              <div :if={@show_version_history} id="version-list" class="mt-3 space-y-2">
+                <div
+                  :for={version <- @versions}
+                  class="flex items-center justify-between rounded-[8px] border border-[var(--border-subtle)] px-3 py-2 text-xs"
+                >
+                  <span class="font-mono text-[var(--text-strong)]">v{version.version}</span>
+                  <span class="text-[var(--text-muted)]">
+                    {if version.version == @agent.latest_version.version,
+                      do: "Current",
+                      else: format_timestamp(version.updated_at)}
+                  </span>
+                </div>
+              </div>
+            </section>
+          </div>
         </div>
       </div>
     </Layouts.app>
@@ -1678,6 +1843,8 @@ defmodule JidoManagedAgentsWeb.AgentBuilderLive do
       {"#{agent.name} (v#{latest})", agent.id}
     end)
   end
+
+  defp section_open?(sections, section), do: MapSet.member?(sections, section)
 
   defp networking_label(environment) do
     get_in(environment.config, ["networking", "type"]) || "unknown"

--- a/lib/jido_managed_agents_web/live/agent_detail_live.ex
+++ b/lib/jido_managed_agents_web/live/agent_detail_live.ex
@@ -1,0 +1,736 @@
+defmodule JidoManagedAgentsWeb.AgentDetailLive do
+  use JidoManagedAgentsWeb, :live_view
+
+  on_mount {JidoManagedAgentsWeb.LiveUserAuth, :live_user_required}
+
+  require Ash.Query
+
+  alias JidoManagedAgents.Agents.Agent
+  alias JidoManagedAgents.Sessions
+  alias JidoManagedAgents.Sessions.Session
+  alias JidoManagedAgents.Sessions.SessionDefinition
+  alias JidoManagedAgents.Sessions.SessionEventDefinition
+  alias JidoManagedAgents.Sessions.SessionEventLog
+  alias JidoManagedAgents.Sessions.SessionRuntime
+  alias JidoManagedAgents.Sessions.SessionSkillLimit
+  alias JidoManagedAgents.Sessions.SessionVault
+  alias JidoManagedAgents.Sessions.Workspace
+  alias JidoManagedAgentsWeb.ConsoleData
+  alias JidoManagedAgentsWeb.ConsoleHelpers
+
+  @impl true
+  def mount(_params, _session, socket) do
+    actor = socket.assigns.current_user
+    environments = Enum.filter(ConsoleData.list_environments(actor), &is_nil(&1.archived_at))
+    vaults = ConsoleData.list_vaults(actor)
+
+    {:ok,
+     socket
+     |> assign_new(:current_scope, fn -> nil end)
+     |> assign(:page_title, "Agent")
+     |> assign(:agent, nil)
+     |> assign(:versions, [])
+     |> assign(:selected_version, nil)
+     |> assign(:current_tab, "agent")
+     |> assign(:agent_sessions, [])
+     |> assign(:environments, environments)
+     |> assign(:vaults, vaults)
+     |> assign(:launch_errors, [])
+     |> assign(:launch_form_params, default_launch_form(environments))
+     |> assign(:launch_form, to_form(default_launch_form(environments), as: :launch))
+     |> assign(:pending_count, ConsoleData.pending_sessions_count(actor))}
+  end
+
+  @impl true
+  def handle_params(%{"id" => id} = params, _uri, socket) do
+    actor = socket.assigns.current_user
+
+    with {:ok, %Agent{} = agent} <- ConsoleData.fetch_agent(id, actor),
+         {:ok, versions} <- ConsoleData.list_agent_versions(agent, actor) do
+      selected_version = resolve_selected_version(versions, Map.get(params, "version"))
+      current_tab = if Map.get(params, "tab") == "sessions", do: "sessions", else: "agent"
+
+      {:noreply,
+       socket
+       |> assign(:agent, agent)
+       |> assign(:versions, versions)
+       |> assign(:selected_version, selected_version)
+       |> assign(:current_tab, current_tab)
+       |> assign(:agent_sessions, ConsoleData.list_agent_sessions(agent.id, actor))
+       |> assign(:page_title, agent.name)}
+    else
+      {:error, :not_found} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "Agent not found.")
+         |> push_navigate(to: ~p"/console/agents")}
+
+      {:error, error} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, ConsoleHelpers.error_message(error))
+         |> push_navigate(to: ~p"/console/agents")}
+    end
+  end
+
+  @impl true
+  def handle_event("choose_version", %{"version" => %{"value" => version}}, socket) do
+    {:noreply,
+     push_patch(socket,
+       to:
+         detail_path(socket.assigns.agent.id,
+           version: version,
+           tab: socket.assigns.current_tab
+         )
+     )}
+  end
+
+  def handle_event("validate_launch", %{"launch" => params}, socket) do
+    params = normalize_launch_form(params, socket.assigns.environments)
+
+    {:noreply,
+     socket
+     |> assign(:launch_form_params, params)
+     |> assign(:launch_form, to_form(params, as: :launch))
+     |> assign(:launch_errors, launch_validation_errors(params))}
+  end
+
+  def handle_event("launch_session", %{"launch" => params}, socket) do
+    actor = socket.assigns.current_user
+    params = normalize_launch_form(params, socket.assigns.environments)
+
+    socket =
+      socket
+      |> assign(:launch_form_params, params)
+      |> assign(:launch_form, to_form(params, as: :launch))
+      |> assign(:launch_errors, launch_validation_errors(params))
+
+    with [] <- socket.assigns.launch_errors,
+         {:ok, %Session{} = session} <- create_session(socket.assigns.agent, params, actor),
+         :ok <- append_prompt(session, params["prompt"], actor),
+         :ok <- start_session_runtime(session.id, actor) do
+      {:noreply,
+       socket
+       |> put_flash(:info, "Session started.")
+       |> push_navigate(to: ~p"/console/sessions/#{session.id}")}
+    else
+      errors when is_list(errors) ->
+        {:noreply, socket}
+
+      {:error, error} ->
+        {:noreply,
+         socket
+         |> assign(:launch_errors, [ConsoleHelpers.error_message(error)])
+         |> put_flash(:error, ConsoleHelpers.error_message(error))}
+    end
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app
+      flash={@flash}
+      current_scope={@current_scope}
+      current_user={@current_user}
+      section={:agents}
+      pending_count={@pending_count}
+    >
+      <div :if={@agent} class="space-y-6">
+        <section class="console-panel space-y-4">
+          <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div class="space-y-3">
+              <div class="flex flex-wrap items-center gap-2">
+                <h1 class="console-title">{@agent.name}</h1>
+                <.status_badge status={if(is_nil(@agent.archived_at), do: "active", else: "archived")} />
+              </div>
+              <p class="console-copy max-w-3xl">{@agent.description || "No description yet."}</p>
+              <p class="console-list-meta">
+                Updated {ConsoleHelpers.format_timestamp(@agent.updated_at)} · {ConsoleHelpers.agent_model(
+                  @selected_version
+                )}
+              </p>
+            </div>
+
+            <div class="flex flex-wrap items-center gap-2">
+              <.form
+                for={%{"value" => @selected_version.version}}
+                as={:version}
+                phx-change="choose_version"
+              >
+                <select
+                  name="version[value]"
+                  class="rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-bg)] px-3 py-2 text-sm text-[var(--text-strong)]"
+                >
+                  <option
+                    :for={version <- @versions}
+                    value={version.version}
+                    selected={version.version == @selected_version.version}
+                  >
+                    v{version.version}{if(version.version == hd(@versions).version,
+                      do: " (latest)",
+                      else: ""
+                    )}
+                  </option>
+                </select>
+              </.form>
+
+              <.link
+                navigate={~p"/console/agents/#{@agent.id}/edit"}
+                class="console-button console-button-secondary"
+              >
+                <.icon name="hero-pencil-square" class="size-4" /> Edit
+              </.link>
+            </div>
+          </div>
+
+          <.console_tabs tabs={[
+            %{
+              label: "Agent",
+              patch: detail_path(@agent.id, version: @selected_version.version, tab: "agent"),
+              active: @current_tab == "agent"
+            },
+            %{
+              label: "Sessions",
+              patch: detail_path(@agent.id, version: @selected_version.version, tab: "sessions"),
+              active: @current_tab == "sessions",
+              count: length(@agent_sessions)
+            }
+          ]} />
+        </section>
+
+        <section
+          :if={@current_tab == "agent"}
+          class="grid gap-6 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]"
+        >
+          <div class="space-y-6">
+            <section class="console-panel space-y-4">
+              <div class="space-y-1">
+                <p class="console-label">Model</p>
+                <h2 class="text-lg font-semibold text-[var(--text-strong)]">
+                  {ConsoleHelpers.agent_model(@selected_version)}
+                </h2>
+              </div>
+              <p class="console-list-meta">
+                Provider: {ConsoleHelpers.payload_value(@selected_version.model, "provider") ||
+                  "unknown"}
+              </p>
+            </section>
+
+            <details class="console-panel" open>
+              <summary class="flex min-h-[44px] cursor-pointer items-center justify-between gap-3 text-left">
+                <span>
+                  <span class="console-label">System Prompt</span>
+                  <span class="block text-lg font-semibold text-[var(--text-strong)]">
+                    Instructions
+                  </span>
+                </span>
+                <.icon name="hero-chevron-down" class="size-4 text-[var(--text-faint)]" />
+              </summary>
+              <div class="pt-4">
+                <pre class="console-code-block">{@selected_version.system || "No system prompt saved for this version."}</pre>
+              </div>
+            </details>
+
+            <details class="console-panel" open>
+              <summary class="flex min-h-[44px] cursor-pointer items-center justify-between gap-3 text-left">
+                <span>
+                  <span class="console-label">Tools</span>
+                  <span class="block text-lg font-semibold text-[var(--text-strong)]">
+                    {length(@selected_version.tools || [])} attached
+                  </span>
+                </span>
+                <.icon name="hero-chevron-down" class="size-4 text-[var(--text-faint)]" />
+              </summary>
+              <div class="space-y-3 pt-4">
+                <div :if={(@selected_version.tools || []) == []}>
+                  <.empty_state
+                    title="No tools"
+                    description="This version does not expose any built-in, MCP, or custom tools."
+                  />
+                </div>
+
+                <div
+                  :for={tool <- @selected_version.tools || []}
+                  class="rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-muted)] p-4"
+                >
+                  <div class="space-y-2">
+                    <div class="flex flex-wrap items-center gap-2">
+                      <p class="text-sm font-semibold text-[var(--text-strong)]">
+                        {Map.get(tool, :name) || Map.get(tool, "name") || Map.get(tool, :type)}
+                      </p>
+                      <.status_badge
+                        status={Map.get(tool, :type) || Map.get(tool, "type")}
+                        size="small"
+                      />
+                      <.status_badge
+                        :if={Map.get(tool, :permission_policy) || Map.get(tool, "permission_policy")}
+                        status={
+                          Map.get(tool, :permission_policy) || Map.get(tool, "permission_policy")
+                        }
+                        size="small"
+                      />
+                    </div>
+                    <p class="console-copy">
+                      {Map.get(tool, :description) || Map.get(tool, "description") ||
+                        "No description yet."}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </details>
+          </div>
+
+          <div class="space-y-6">
+            <details class="console-panel" open>
+              <summary class="flex min-h-[44px] cursor-pointer items-center justify-between gap-3 text-left">
+                <span>
+                  <span class="console-label">MCP Servers</span>
+                  <span class="block text-lg font-semibold text-[var(--text-strong)]">
+                    {length(@selected_version.mcp_servers || [])} connected
+                  </span>
+                </span>
+                <.icon name="hero-chevron-down" class="size-4 text-[var(--text-faint)]" />
+              </summary>
+              <div class="space-y-3 pt-4">
+                <div :if={(@selected_version.mcp_servers || []) == []}>
+                  <.empty_state
+                    title="No MCP servers"
+                    description="This version runs without any remote MCP endpoints."
+                  />
+                </div>
+
+                <div
+                  :for={server <- @selected_version.mcp_servers || []}
+                  class="rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-muted)] p-4"
+                >
+                  <div class="space-y-2">
+                    <div class="flex flex-wrap items-center gap-2">
+                      <p class="text-sm font-semibold text-[var(--text-strong)]">
+                        {Map.get(server, "name") || Map.get(server, :name)}
+                      </p>
+                      <.status_badge
+                        status={Map.get(server, "type") || Map.get(server, :type) || "mcp"}
+                        size="small"
+                      />
+                    </div>
+                    <p class="console-list-meta">
+                      {Map.get(server, "url") || Map.get(server, :url) || "No URL"}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </details>
+
+            <section class="console-panel space-y-4">
+              <div class="space-y-1">
+                <p class="console-label">Skills</p>
+                <h2 class="text-lg font-semibold text-[var(--text-strong)]">
+                  {length(@selected_version.agent_version_skills || [])} linked
+                </h2>
+              </div>
+              <div :if={(@selected_version.agent_version_skills || []) == []}>
+                <.empty_state
+                  title="No skills"
+                  description="This version runs without pinned skill references."
+                />
+              </div>
+              <div :if={(@selected_version.agent_version_skills || []) != []} class="space-y-3">
+                <div
+                  :for={link <- @selected_version.agent_version_skills || []}
+                  class="rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-muted)] p-4"
+                >
+                  <div class="flex flex-wrap items-center gap-2">
+                    <p class="text-sm font-semibold text-[var(--text-strong)]">
+                      {link.skill.name}
+                    </p>
+                    <.status_badge status={link.kind || "skill"} size="small" />
+                    <span
+                      :if={link.skill_version}
+                      class="console-badge console-badge-neutral px-2 py-1 text-[10px]"
+                    >
+                      v{link.skill_version.version}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <section class="console-panel space-y-4">
+              <div class="space-y-1">
+                <p class="console-label">Callable Agents</p>
+                <h2 class="text-lg font-semibold text-[var(--text-strong)]">
+                  {length(@selected_version.agent_version_callable_agents || [])} available
+                </h2>
+              </div>
+              <div :if={(@selected_version.agent_version_callable_agents || []) == []}>
+                <.empty_state
+                  title="No callable agents"
+                  description="This version does not delegate to any sibling agents."
+                />
+              </div>
+              <div
+                :if={(@selected_version.agent_version_callable_agents || []) != []}
+                class="space-y-3"
+              >
+                <div
+                  :for={link <- @selected_version.agent_version_callable_agents || []}
+                  class="rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-muted)] p-4"
+                >
+                  <div class="flex flex-wrap items-center gap-2">
+                    <p class="text-sm font-semibold text-[var(--text-strong)]">
+                      {link.callable_agent.name}
+                    </p>
+                    <span
+                      :if={link.callable_agent_version}
+                      class="console-badge console-badge-neutral px-2 py-1 text-[10px]"
+                    >
+                      v{link.callable_agent_version.version}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <details :if={map_size(@selected_version.metadata || %{}) > 0} class="console-panel">
+              <summary class="flex min-h-[44px] cursor-pointer items-center justify-between gap-3 text-left">
+                <span>
+                  <span class="console-label">Metadata</span>
+                  <span class="block text-lg font-semibold text-[var(--text-strong)]">
+                    Structured fields
+                  </span>
+                </span>
+                <.icon name="hero-chevron-down" class="size-4 text-[var(--text-faint)]" />
+              </summary>
+              <div class="pt-4">
+                <.json_block data={@selected_version.metadata} />
+              </div>
+            </details>
+          </div>
+        </section>
+
+        <section
+          :if={@current_tab == "sessions"}
+          class="grid gap-6 xl:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]"
+        >
+          <section class="console-panel space-y-4">
+            <div class="space-y-1">
+              <p class="console-label">Start Session</p>
+              <h2 class="text-lg font-semibold text-[var(--text-strong)]">
+                Open a conversation with this agent
+              </h2>
+            </div>
+
+            <div
+              :if={@launch_errors != []}
+              class="rounded-[8px] border border-[var(--danger)]/20 bg-[var(--danger-soft)] p-4 text-sm text-[var(--danger)]"
+            >
+              <p :for={error <- @launch_errors}>{error}</p>
+            </div>
+
+            <.form
+              for={@launch_form}
+              id="agent-launch-form"
+              class="space-y-4"
+              phx-change="validate_launch"
+              phx-submit="launch_session"
+            >
+              <div class="grid gap-4 md:grid-cols-2">
+                <div>
+                  <label class="console-label" for="launch-title">Title</label>
+                  <input
+                    id="launch-title"
+                    name="launch[title]"
+                    value={@launch_form_params["title"]}
+                    placeholder="Sprint retro facilitator"
+                    class="w-full rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-bg)] px-3 py-3 text-sm text-[var(--text-strong)] outline-none transition focus:border-[var(--border-strong)]"
+                  />
+                </div>
+                <div>
+                  <label class="console-label" for="launch-environment">Environment</label>
+                  <select
+                    id="launch-environment"
+                    name="launch[environment_id]"
+                    class="w-full rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-bg)] px-3 py-3 text-sm text-[var(--text-strong)] outline-none transition focus:border-[var(--border-strong)]"
+                  >
+                    <option
+                      :for={environment <- @environments}
+                      value={environment.id}
+                      selected={environment.id == @launch_form_params["environment_id"]}
+                    >
+                      {environment.name}
+                    </option>
+                  </select>
+                </div>
+              </div>
+
+              <div>
+                <label class="console-label" for="launch-prompt">Opening message</label>
+                <textarea
+                  id="launch-prompt"
+                  name="launch[prompt]"
+                  rows="5"
+                  placeholder="Ask the agent to do the first piece of work here."
+                  class="w-full rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-bg)] px-3 py-3 text-sm leading-7 text-[var(--text-strong)] outline-none transition focus:border-[var(--border-strong)]"
+                >{@launch_form_params["prompt"]}</textarea>
+                <p class="console-field-note">
+                  This becomes the first `user.message` turn so the session detail page opens with a real conversation history.
+                </p>
+              </div>
+
+              <div :if={@vaults != []} class="space-y-3">
+                <p class="console-label">Vaults</p>
+                <div class="grid gap-3">
+                  <label
+                    :for={vault <- @vaults}
+                    class="flex min-h-[44px] items-center gap-3 rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-muted)] px-3 py-3"
+                  >
+                    <input
+                      type="checkbox"
+                      name="launch[vault_ids][]"
+                      value={vault.id}
+                      checked={vault.id in List.wrap(@launch_form_params["vault_ids"])}
+                      class="size-4 rounded border-[var(--border-strong)] text-[var(--brand)]"
+                    />
+                    <span class="min-w-0">
+                      <span class="block text-sm font-medium text-[var(--text-strong)]">
+                        {vault.name}
+                      </span>
+                      <span class="block text-xs text-[var(--text-muted)]">
+                        {vault.description || "No description yet."}
+                      </span>
+                    </span>
+                  </label>
+                </div>
+              </div>
+
+              <div class="flex flex-wrap gap-3">
+                <button type="submit" class="console-button console-button-primary">
+                  <.icon name="hero-paper-airplane" class="size-4" /> Start Session
+                </button>
+                <.link
+                  navigate={~p"/console/sessions"}
+                  class="console-button console-button-secondary"
+                >
+                  View All Sessions
+                </.link>
+              </div>
+            </.form>
+          </section>
+
+          <section class="console-panel space-y-4">
+            <div class="space-y-1">
+              <p class="console-label">Recent Sessions</p>
+              <h2 class="text-lg font-semibold text-[var(--text-strong)]">This agent's history</h2>
+            </div>
+
+            <div :if={@agent_sessions == []}>
+              <.empty_state
+                title="No sessions yet"
+                description="Start the first session for this agent from the form on the left."
+              />
+            </div>
+
+            <div :if={@agent_sessions != []} class="space-y-3">
+              <.link
+                :for={session <- @agent_sessions}
+                navigate={~p"/console/sessions/#{session.id}"}
+                class="console-list-link"
+              >
+                <div class="space-y-2">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <p class="truncate text-sm font-semibold text-[var(--text-strong)]">
+                      {session.title || ConsoleHelpers.short_id(session.id)}
+                    </p>
+                    <.status_badge status={
+                      if(ConsoleHelpers.requires_action?(session.stop_reason),
+                        do: "needs_input",
+                        else: session.status
+                      )
+                    } />
+                  </div>
+                  <p class="console-list-meta">
+                    {ConsoleHelpers.session_model(session)} · {length(session.threads || [])} thread(s) · {ConsoleHelpers.format_timestamp(
+                      session.created_at
+                    )}
+                  </p>
+                </div>
+              </.link>
+            </div>
+          </section>
+        </section>
+      </div>
+    </Layouts.app>
+    """
+  end
+
+  defp resolve_selected_version([version | _rest], nil), do: version
+
+  defp resolve_selected_version(versions, value) do
+    version_number =
+      case Integer.parse(to_string(value)) do
+        {parsed, _rest} -> parsed
+        :error -> nil
+      end
+
+    Enum.find(versions, hd(versions), &(&1.version == version_number))
+  end
+
+  defp detail_path(agent_id, params) do
+    version = params[:version]
+    tab = params[:tab]
+    ~p"/console/agents/#{agent_id}?version=#{version}&tab=#{tab}"
+  end
+
+  defp default_launch_form(environments) do
+    %{
+      "environment_id" => default_environment_id(environments),
+      "title" => "",
+      "prompt" => "",
+      "vault_ids" => []
+    }
+  end
+
+  defp normalize_launch_form(params, environments) when is_map(params) do
+    %{
+      "environment_id" => Map.get(params, "environment_id", default_environment_id(environments)),
+      "title" => Map.get(params, "title", ""),
+      "prompt" => Map.get(params, "prompt", ""),
+      "vault_ids" => Enum.reject(List.wrap(Map.get(params, "vault_ids", [])), &(&1 in [nil, ""]))
+    }
+  end
+
+  defp default_environment_id([environment | _rest]), do: environment.id
+  defp default_environment_id([]), do: ""
+
+  defp launch_validation_errors(params) do
+    []
+    |> maybe_add_error(params["environment_id"] in [nil, ""], "Select an environment.")
+    |> maybe_add_error(String.trim(params["prompt"] || "") == "", "Opening message is required.")
+  end
+
+  defp maybe_add_error(errors, true, error), do: errors ++ [error]
+  defp maybe_add_error(errors, false, _error), do: errors
+
+  defp create_session(%Agent{} = agent, params, actor) do
+    session_params =
+      %{
+        "agent" => agent.id,
+        "environment_id" => params["environment_id"],
+        "title" => ConsoleHelpers.blank_to_nil(params["title"]),
+        "vault_ids" => List.wrap(params["vault_ids"])
+      }
+      |> ConsoleHelpers.compact_map()
+
+    with {:ok, payload} <- SessionDefinition.normalize_create_payload(session_params, actor) do
+      create_session_record(payload, actor)
+    end
+  end
+
+  defp create_session_record(%{agent: %Agent{} = agent, session: attrs}, actor) do
+    opts = [actor: actor, domain: Sessions]
+    resources = [Workspace, Session, SessionVault]
+
+    with :ok <- SessionSkillLimit.validate(Map.get(attrs, :agent_version_id), actor) do
+      Ash.transact(resources, fn ->
+        with {:ok, %Workspace{} = workspace} <- resolve_or_create_workspace(agent, actor),
+             {:ok, %Session{} = session} <- create_persisted_session(attrs, workspace, opts),
+             {:ok, %Session{} = loaded_session} <- load_session(session.id, actor) do
+          loaded_session
+        end
+      end)
+    end
+    |> map_create_session_error()
+  end
+
+  defp resolve_or_create_workspace(%Agent{} = agent, actor) do
+    query =
+      Workspace
+      |> Ash.Query.for_read(:read, %{}, actor: actor, domain: Sessions)
+      |> Ash.Query.filter(user_id == ^actor.id and agent_id == ^agent.id)
+
+    case Ash.read_one(query) do
+      {:ok, %Workspace{} = workspace} ->
+        {:ok, workspace}
+
+      {:ok, nil} ->
+        Workspace
+        |> Ash.Changeset.for_create(
+          :create,
+          %{
+            user_id: actor.id,
+            agent_id: agent.id,
+            name: "#{agent.name} workspace"
+          },
+          actor: actor,
+          domain: Sessions
+        )
+        |> Ash.create(
+          upsert?: true,
+          upsert_identity: :unique_workspace_per_user_agent,
+          upsert_fields: [],
+          touch_update_defaults?: false
+        )
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  defp create_persisted_session(attrs, %Workspace{} = workspace, opts) do
+    Session
+    |> Ash.Changeset.for_create(:create, Map.put(attrs, :workspace_id, workspace.id), opts)
+    |> Ash.create()
+  end
+
+  defp load_session(session_id, actor) do
+    query =
+      Session
+      |> Ash.Query.for_read(:by_id, %{id: session_id}, actor: actor, domain: Sessions)
+      |> Ash.Query.load([:agent_version, :session_vaults])
+
+    case Ash.read_one(query) do
+      {:ok, %Session{} = session} -> {:ok, session}
+      {:ok, nil} -> {:error, :not_found}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  defp append_prompt(_session, prompt, _actor) when prompt in [nil, ""], do: :ok
+
+  defp append_prompt(%Session{} = session, prompt, actor) do
+    params = %{
+      "type" => "user.message",
+      "content" => [%{"type" => "text", "text" => prompt}]
+    }
+
+    with {:ok, events} <- SessionEventDefinition.normalize_append_payload(params, session, actor),
+         {:ok, _appended_events} <- SessionEventLog.append_user_events(session, events, actor) do
+      :ok
+    end
+  end
+
+  defp start_session_runtime(session_id, actor) do
+    case Task.Supervisor.start_child(JidoManagedAgents.TaskSupervisor, fn ->
+           try do
+             SessionRuntime.run(session_id, actor)
+           rescue
+             _error -> :error
+           end
+         end) do
+      {:ok, _pid} -> :ok
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  defp map_create_session_error({:error, %Ash.Error.Invalid{} = error}) do
+    if Exception.message(error) =~ "workspace already has an active session" do
+      {:error,
+       {:conflict,
+        "This agent already has an active workspace session. Open it from Sessions or finish it before starting a new one."}}
+    else
+      {:error, error}
+    end
+  end
+
+  defp map_create_session_error(result), do: result
+end

--- a/lib/jido_managed_agents_web/live/agents_library_live.ex
+++ b/lib/jido_managed_agents_web/live/agents_library_live.ex
@@ -1,0 +1,173 @@
+defmodule JidoManagedAgentsWeb.AgentsLibraryLive do
+  use JidoManagedAgentsWeb, :live_view
+
+  on_mount {JidoManagedAgentsWeb.LiveUserAuth, :live_user_required}
+
+  alias JidoManagedAgentsWeb.ConsoleData
+  alias JidoManagedAgentsWeb.ConsoleHelpers
+
+  @impl true
+  def mount(_params, _session, socket) do
+    actor = socket.assigns.current_user
+    agents = ConsoleData.list_agents(actor)
+    filters = default_filters()
+
+    {:ok,
+     socket
+     |> assign_new(:current_scope, fn -> nil end)
+     |> assign(:page_title, "Agents")
+     |> assign(:all_agents, agents)
+     |> assign(:filters, filters)
+     |> assign(:filter_form, to_form(filters, as: :filters))
+     |> assign(:agents, filter_agents(agents, filters))
+     |> assign(:pending_count, ConsoleData.pending_sessions_count(actor))}
+  end
+
+  @impl true
+  def handle_event("filter", %{"filters" => params}, socket) do
+    filters = normalize_filters(params)
+
+    {:noreply,
+     socket
+     |> assign(:filters, filters)
+     |> assign(:filter_form, to_form(filters, as: :filters))
+     |> assign(:agents, filter_agents(socket.assigns.all_agents, filters))}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app
+      flash={@flash}
+      current_scope={@current_scope}
+      current_user={@current_user}
+      section={:agents}
+      pending_count={@pending_count}
+    >
+      <.page_header
+        title="Agents"
+        description="Browse the catalog, inspect current versions, and move into a read-first detail screen before editing."
+      >
+        <:actions>
+          <.link navigate={~p"/console/agents/new"} class="console-button console-button-primary">
+            <.icon name="hero-plus" class="size-4" /> Create Agent
+          </.link>
+        </:actions>
+      </.page_header>
+
+      <section class="console-panel space-y-4">
+        <.form
+          for={@filter_form}
+          id="agent-filters"
+          class="flex flex-col gap-3 md:flex-row md:items-center"
+          phx-change="filter"
+        >
+          <div class="relative min-w-0 flex-1">
+            <span class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-faint)]">
+              <.icon name="hero-magnifying-glass" class="size-4" />
+            </span>
+            <input
+              type="text"
+              name="filters[search]"
+              value={@filters["search"]}
+              placeholder="Search agents"
+              class="w-full rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-bg)] px-10 py-3 text-sm text-[var(--text-strong)] outline-none transition focus:border-[var(--border-strong)]"
+            />
+          </div>
+
+          <div class="flex flex-wrap gap-2">
+            <button
+              :for={filter <- [{"all", "All"}, {"active", "Active"}, {"archived", "Archived"}]}
+              type="submit"
+              name="filters[status]"
+              value={elem(filter, 0)}
+              class={[
+                "console-button",
+                if(@filters["status"] == elem(filter, 0),
+                  do: "console-button-primary",
+                  else: "console-button-secondary"
+                )
+              ]}
+            >
+              {elem(filter, 1)}
+            </button>
+          </div>
+        </.form>
+      </section>
+
+      <section class="space-y-3">
+        <div :if={@agents == []}>
+          <.empty_state
+            title="No agents matched"
+            description="Try a broader search or clear the archived filter."
+          />
+        </div>
+
+        <.link
+          :for={agent <- @agents}
+          navigate={~p"/console/agents/#{agent.id}"}
+          class="console-list-link"
+        >
+          <div class="console-list-row">
+            <div class="min-w-0 space-y-2">
+              <div class="flex flex-wrap items-center gap-2">
+                <p class="truncate text-sm font-semibold text-[var(--text-strong)]">{agent.name}</p>
+                <span class="console-badge console-badge-neutral px-2 py-1 text-[10px]">
+                  v{agent.latest_version.version}
+                </span>
+                <.status_badge :if={!is_nil(agent.archived_at)} status="archived" size="small" />
+              </div>
+              <p class="console-copy line-clamp-2 max-w-3xl">
+                {agent.description || "No description yet."}
+              </p>
+              <p class="console-list-meta">
+                {ConsoleHelpers.agent_model(agent.latest_version)} · Updated {ConsoleHelpers.format_timestamp(
+                  agent.updated_at
+                )}
+              </p>
+            </div>
+
+            <.icon name="hero-chevron-right" class="mt-1 size-4 shrink-0 text-[var(--text-faint)]" />
+          </div>
+        </.link>
+      </section>
+    </Layouts.app>
+    """
+  end
+
+  defp default_filters do
+    %{"search" => "", "status" => "all"}
+  end
+
+  defp normalize_filters(params) do
+    %{
+      "search" => Map.get(params, "search", ""),
+      "status" => Map.get(params, "status", "all")
+    }
+  end
+
+  defp filter_agents(agents, filters) do
+    search = filters["search"] |> String.downcase() |> String.trim()
+    status = filters["status"]
+
+    Enum.filter(agents, fn agent ->
+      matches_status? = status_match?(agent, status)
+      matches_search? = search == "" or search_match?(agent, search)
+      matches_status? and matches_search?
+    end)
+  end
+
+  defp status_match?(agent, "active"), do: is_nil(agent.archived_at)
+  defp status_match?(agent, "archived"), do: not is_nil(agent.archived_at)
+  defp status_match?(_agent, _status), do: true
+
+  defp search_match?(agent, search) do
+    haystack =
+      [agent.name, agent.description, ConsoleHelpers.agent_model(agent.latest_version)]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.join(" ")
+      |> String.downcase()
+
+    String.contains?(haystack, search)
+  end
+end

--- a/lib/jido_managed_agents_web/live/api_docs_live.ex
+++ b/lib/jido_managed_agents_web/live/api_docs_live.ex
@@ -1,0 +1,157 @@
+defmodule JidoManagedAgentsWeb.ApiDocsLive do
+  use JidoManagedAgentsWeb, :live_view
+
+  on_mount {JidoManagedAgentsWeb.LiveUserAuth, :live_user_required}
+
+  alias JidoManagedAgentsWeb.ConsoleData
+
+  @snippets %{
+    "Agents" => %{
+      method: "POST",
+      path: "/v1/agents",
+      description: "Create a new agent",
+      body: %{
+        name: "Coding Assistant",
+        model: %{provider: "anthropic", model_id: "claude-sonnet-4-20250514"},
+        system_prompt: "You are a senior software engineer."
+      }
+    },
+    "Sessions" => %{
+      method: "POST",
+      path: "/v1/sessions",
+      description: "Launch a new session",
+      body: %{
+        agent_id: "agt_01",
+        environment_id: "env_01",
+        title: "Debug auth flow",
+        vault_ids: ["vlt_01"]
+      }
+    },
+    "Vaults" => %{
+      method: "POST",
+      path: "/v1/vaults",
+      description: "Create a vault",
+      body: %{
+        name: "Production Secrets",
+        description: "Credentials for production MCP servers"
+      }
+    },
+    "Environments" => %{
+      method: "POST",
+      path: "/v1/environments",
+      description: "Create a runtime template",
+      body: %{
+        name: "Restricted Demo Sandbox",
+        runtime: "cloud",
+        networking: "restricted"
+      }
+    }
+  }
+
+  @impl true
+  def mount(_params, _session, socket) do
+    actor = socket.assigns.current_user
+
+    {:ok,
+     socket
+     |> assign_new(:current_scope, fn -> nil end)
+     |> assign(:page_title, "API Docs")
+     |> assign(:active_resource, "Agents")
+     |> assign(:pending_count, ConsoleData.pending_sessions_count(actor))}
+  end
+
+  @impl true
+  def handle_event("select_resource", %{"resource" => resource}, socket) do
+    {:noreply, assign(socket, :active_resource, resource)}
+  end
+
+  @impl true
+  def render(assigns) do
+    snippet = Map.fetch!(@snippets, assigns.active_resource)
+
+    assigns = assign(assigns, :snippet, snippet)
+
+    ~H"""
+    <Layouts.app
+      flash={@flash}
+      current_scope={@current_scope}
+      current_user={@current_user}
+      section={:api}
+      pending_count={@pending_count}
+    >
+      <.page_header
+        title="API Documentation"
+        description="Anthropic-shaped `/v1` endpoints for agents, sessions, environments, and vault-backed credentials."
+      >
+        <:actions>
+          <.link href={~p"/api/json/swaggerui"} class="console-button console-button-secondary">
+            <.icon name="hero-arrow-top-right-on-square" class="size-4" /> Open Swagger UI
+          </.link>
+        </:actions>
+      </.page_header>
+
+      <section class="grid gap-6 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
+        <section class="console-panel space-y-3">
+          <div class="space-y-1">
+            <p class="console-label">Resources</p>
+            <h2 class="text-lg font-semibold text-[var(--text-strong)]">Example requests</h2>
+          </div>
+
+          <button
+            :for={resource <- Map.keys(@snippets)}
+            type="button"
+            phx-click="select_resource"
+            phx-value-resource={resource}
+            class={[
+              "console-list-button",
+              @active_resource == resource && "console-list-button-selected"
+            ]}
+          >
+            <div class="space-y-1">
+              <p class="text-sm font-semibold text-[var(--text-strong)]">{resource}</p>
+              <p class="console-list-meta">{resource_description(resource)}</p>
+            </div>
+          </button>
+        </section>
+
+        <section class="console-panel space-y-4">
+          <div class="space-y-1">
+            <p class="console-label">Request</p>
+            <h2 class="text-lg font-semibold text-[var(--text-strong)]">{@snippet.description}</h2>
+            <p class="console-list-meta">
+              <span class="console-badge console-badge-info px-2 py-1 text-[10px]">
+                {@snippet.method}
+              </span>
+              <span class="ml-2 font-mono">{@snippet.path}</span>
+            </p>
+          </div>
+
+          <div>
+            <p class="console-label">Request Body</p>
+            <.json_block data={@snippet.body} />
+          </div>
+
+          <div>
+            <p class="console-label">Example cURL</p>
+            <pre class="console-code-block">{curl_command(@snippet)}</pre>
+          </div>
+        </section>
+      </section>
+    </Layouts.app>
+    """
+  end
+
+  defp resource_description("Agents"), do: "Create, version, and manage agent configurations."
+  defp resource_description("Sessions"), do: "Launch, stream, and append to agent session runs."
+  defp resource_description("Vaults"), do: "Register vaults and secure credentials."
+  defp resource_description("Environments"), do: "Manage runtime templates and networking policy."
+  defp resource_description(_resource), do: "Example request."
+
+  defp curl_command(snippet) do
+    """
+    curl -X #{snippet.method} http://localhost:4000#{snippet.path} \\
+      -H "Content-Type: application/json" \\
+      -d '#{Jason.encode!(snippet.body)}'
+    """
+  end
+end

--- a/lib/jido_managed_agents_web/live/console_data.ex
+++ b/lib/jido_managed_agents_web/live/console_data.ex
@@ -1,0 +1,150 @@
+defmodule JidoManagedAgentsWeb.ConsoleData do
+  @moduledoc false
+
+  require Ash.Query
+
+  alias JidoManagedAgents.Agents
+  alias JidoManagedAgents.Agents.Agent
+  alias JidoManagedAgents.Agents.AgentCatalog
+  alias JidoManagedAgents.Agents.Environment
+  alias JidoManagedAgents.Agents.Skill
+  alias JidoManagedAgents.Integrations
+  alias JidoManagedAgents.Integrations.Credential
+  alias JidoManagedAgents.Integrations.Vault
+  alias JidoManagedAgents.Sessions
+  alias JidoManagedAgents.Sessions.Session
+  alias JidoManagedAgents.Sessions.SessionEvent
+
+  def list_agents(actor) do
+    Agent
+    |> Ash.Query.for_read(:read, %{}, actor: actor, domain: Agents)
+    |> Ash.Query.sort(updated_at: :desc)
+    |> Ash.Query.load(AgentCatalog.latest_version_load())
+    |> Ash.read!()
+  end
+
+  def fetch_agent(id, actor),
+    do: AgentCatalog.fetch_agent(id, actor, AgentCatalog.latest_version_load())
+
+  def list_agent_versions(%Agent{} = agent, actor), do: AgentCatalog.list_versions(agent, actor)
+
+  def list_agent_sessions(agent_id, actor) do
+    Session
+    |> Ash.Query.for_read(:read, %{}, actor: actor, domain: Sessions)
+    |> Ash.Query.filter(agent_id == ^agent_id)
+    |> Ash.Query.sort(updated_at: :desc)
+    |> Ash.Query.load([:agent, :agent_version, :environment, :vaults, :threads])
+    |> Ash.read!()
+  end
+
+  def list_environments(actor) do
+    Environment
+    |> Ash.Query.for_read(:read, %{}, actor: actor, domain: Agents)
+    |> Ash.Query.sort(updated_at: :desc)
+    |> Ash.read!()
+  end
+
+  def fetch_environment(id, actor) do
+    Environment
+    |> Ash.Query.for_read(:by_id, %{id: id}, actor: actor, domain: Agents)
+    |> Ash.read_one()
+    |> case do
+      {:ok, nil} -> {:error, :not_found}
+      {:ok, %Environment{} = environment} -> {:ok, environment}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  def list_skills(actor) do
+    Skill
+    |> Ash.Query.for_read(:read, %{}, actor: actor, domain: Agents)
+    |> Ash.Query.filter(is_nil(archived_at))
+    |> Ash.Query.sort(name: :asc)
+    |> Ash.Query.load(:latest_version_number)
+    |> Ash.read!()
+  end
+
+  def list_vaults(actor) do
+    Vault
+    |> Ash.Query.for_read(:read, %{}, actor: actor, domain: Integrations)
+    |> Ash.Query.sort(updated_at: :desc)
+    |> Ash.read!()
+  end
+
+  def fetch_vault(id, actor) do
+    Vault
+    |> Ash.Query.for_read(:by_id, %{id: id}, actor: actor, domain: Integrations)
+    |> Ash.read_one()
+    |> case do
+      {:ok, nil} -> {:error, :not_found}
+      {:ok, %Vault{} = vault} -> {:ok, vault}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  def count_credentials(actor) do
+    Credential
+    |> Ash.Query.for_read(:read, %{}, actor: actor, domain: Integrations)
+    |> Ash.read!()
+    |> length()
+  end
+
+  def list_sessions(actor, opts \\ []) do
+    limit = Keyword.get(opts, :limit)
+
+    Session
+    |> Ash.Query.for_read(:read, %{}, actor: actor, domain: Sessions)
+    |> Ash.Query.sort(updated_at: :desc)
+    |> maybe_limit(limit)
+    |> Ash.Query.load([:agent, :agent_version, :environment, :vaults, threads: [:agent]])
+    |> Ash.read!()
+  end
+
+  def fetch_session(id, actor) do
+    Session
+    |> Ash.Query.for_read(:by_id, %{id: id}, actor: actor, domain: Sessions)
+    |> Ash.Query.load([
+      :agent,
+      :agent_version,
+      :environment,
+      :vaults,
+      threads: [:agent, :agent_version]
+    ])
+    |> Ash.read_one()
+    |> case do
+      {:ok, nil} -> {:error, :not_found}
+      {:ok, %Session{} = session} -> {:ok, session}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  def list_session_events(%Session{} = session, actor, opts \\ []) do
+    limit = Keyword.get(opts, :limit)
+    thread_id = Keyword.get(opts, :thread_id)
+
+    SessionEvent
+    |> Ash.Query.for_read(:read, %{}, actor: actor, domain: Sessions)
+    |> filter_session_events(session.id, thread_id)
+    |> Ash.Query.sort(sequence: :desc)
+    |> maybe_limit(limit)
+    |> Ash.read!()
+    |> Enum.reverse()
+  end
+
+  def pending_sessions_count(actor) do
+    actor
+    |> list_sessions(limit: 100)
+    |> Enum.count(&JidoManagedAgentsWeb.ConsoleHelpers.requires_action?(&1.stop_reason))
+  end
+
+  defp filter_session_events(query, session_id, nil) do
+    Ash.Query.filter(query, session_id == ^session_id)
+  end
+
+  defp filter_session_events(query, session_id, thread_id) do
+    Ash.Query.filter(query, session_id == ^session_id and session_thread_id == ^thread_id)
+  end
+
+  defp maybe_limit(query, nil), do: query
+  defp maybe_limit(query, limit), do: Ash.Query.limit(query, limit)
+end

--- a/lib/jido_managed_agents_web/live/console_helpers.ex
+++ b/lib/jido_managed_agents_web/live/console_helpers.ex
@@ -58,4 +58,89 @@ defmodule JidoManagedAgentsWeb.ConsoleHelpers do
   def format_timestamp(%DateTime{} = timestamp) do
     Calendar.strftime(timestamp, "%Y-%m-%d %H:%M UTC")
   end
+
+  def short_id(nil), do: "unknown"
+  def short_id(id) when is_binary(id), do: String.slice(id, 0, 8)
+
+  def status_label(status) when is_atom(status),
+    do: status |> Atom.to_string() |> String.capitalize()
+
+  def status_label(status) when is_binary(status), do: String.capitalize(status)
+  def status_label(_status), do: "Unknown"
+
+  def truthy?(value), do: value in [true, "true", 1, "1"]
+
+  def requires_action?(stop_reason), do: requires_action_event_ids(stop_reason) != []
+
+  def requires_action_event_ids(%{} = stop_reason) do
+    if payload_value(stop_reason, "type") == "requires_action" do
+      stop_reason
+      |> payload_value("event_ids")
+      |> List.wrap()
+      |> Enum.filter(&is_binary/1)
+    else
+      []
+    end
+  end
+
+  def requires_action_event_ids(_stop_reason), do: []
+
+  def payload_value(payload, key) when is_map(payload) do
+    Map.get(payload, key) || existing_atom_value(payload, key)
+  rescue
+    ArgumentError -> Map.get(payload, key)
+  end
+
+  def payload_value(_payload, _key), do: nil
+
+  def text_content(content) when is_list(content) do
+    content
+    |> Enum.map(fn
+      %{"text" => text} when is_binary(text) -> text
+      %{text: text} when is_binary(text) -> text
+      _other -> nil
+    end)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("\n")
+    |> String.trim()
+  end
+
+  def text_content(_content), do: ""
+
+  def pretty_data(nil), do: "(none)"
+  def pretty_data(value) when is_binary(value), do: value
+
+  def pretty_data(value) when is_map(value) or is_list(value) do
+    Jason.encode!(value, pretty: true)
+  end
+
+  def pretty_data(value), do: inspect(value, pretty: true)
+
+  def session_model(%{agent_version: %{model: model}}) when is_map(model) do
+    payload_value(model, "id") || payload_value(model, "model_id") || "Unknown model"
+  end
+
+  def session_model(_session), do: "Unknown model"
+
+  def agent_model(%{model: model}) when is_map(model) do
+    payload_value(model, "id") || payload_value(model, "model_id") || "Unknown model"
+  end
+
+  def agent_model(%{latest_version: %{model: model}}) when is_map(model) do
+    payload_value(model, "id") || payload_value(model, "model_id") || "Unknown model"
+  end
+
+  def agent_model(_agent), do: "Unknown model"
+
+  def networking_label(%{config: config}) when is_map(config) do
+    get_in(config, ["networking", "type"]) || get_in(config, [:networking, :type]) || "restricted"
+  end
+
+  def networking_label(_environment), do: "restricted"
+
+  defp existing_atom_value(payload, key) do
+    key
+    |> String.to_existing_atom()
+    |> then(&Map.get(payload, &1))
+  end
 end

--- a/lib/jido_managed_agents_web/live/environment_console_live.ex
+++ b/lib/jido_managed_agents_web/live/environment_console_live.ex
@@ -20,6 +20,7 @@ defmodule JidoManagedAgentsWeb.EnvironmentConsoleLive do
       |> assign_new(:current_scope, fn -> nil end)
       |> assign(:page_title, "Environments")
       |> assign(:environments, environments)
+      |> assign(:environment_filter, "all")
       |> assign(:selected_environment, nil)
       |> assign(:environment_errors, [])
       |> assign_environment_form(default_environment_params())
@@ -65,6 +66,11 @@ defmodule JidoManagedAgentsWeb.EnvironmentConsoleLive do
   @impl true
   def handle_event("validate_environment", %{"environment" => params}, socket) do
     {:noreply, assign_environment_form(socket, params)}
+  end
+
+  def handle_event("set_filter", %{"filter" => filter}, socket)
+      when filter in ["all", "active", "archived"] do
+    {:noreply, assign(socket, :environment_filter, filter)}
   end
 
   def handle_event("save_environment", %{"environment" => params}, socket) do
@@ -118,207 +124,161 @@ defmodule JidoManagedAgentsWeb.EnvironmentConsoleLive do
       flash={@flash}
       current_scope={@current_scope}
       current_user={@current_user}
-      main_class="px-4 py-8 sm:px-6 lg:px-8"
-      container_class="mx-auto max-w-7xl space-y-8"
+      section={:environments}
+      main_class="px-4 py-6 sm:px-6 lg:px-8"
+      container_class="mx-auto max-w-7xl space-y-6"
     >
-      <section class="overflow-hidden rounded-[2rem] border border-emerald-200/70 bg-[radial-gradient(circle_at_top_left,_rgba(16,185,129,0.18),_transparent_40%),linear-gradient(135deg,_#052e2b,_#0f172a_58%,_#134e4a)] text-white shadow-2xl shadow-emerald-950/20">
-        <div class="grid gap-8 px-6 py-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)] lg:px-10">
-          <div class="space-y-4">
-            <p class="text-xs font-semibold uppercase tracking-[0.28em] text-emerald-200">
-              Resource Templates
-            </p>
-            <h1 class="max-w-3xl text-3xl font-semibold tracking-tight sm:text-4xl">
-              Environments
-            </h1>
-            <p class="max-w-2xl text-sm leading-6 text-emerald-50/80">
-              Define reusable runtime templates, keep networking explicit, and archive old configurations without losing the audit trail for past sessions.
-            </p>
-            <div class="flex flex-wrap gap-3 pt-2">
-              <.console_tab navigate={~p"/console/agents/new"} label="Agents" />
-              <.console_tab active label="Environments" />
-              <.console_tab navigate={~p"/console/vaults"} label="Vaults" />
-            </div>
+      <.page_header
+        title="Environments"
+        description="Manage reusable runtime templates for agent sessions."
+      />
+
+      <div class="flex items-center gap-4 text-xs text-[var(--text-muted)]">
+        <span>{active_environment_count(@environments)} active</span>
+        <span class="text-[var(--border-strong)]">·</span>
+        <span>{archived_environment_count(@environments)} archived</span>
+      </div>
+
+      <div class="grid gap-6 lg:grid-cols-5">
+        <section class="space-y-3 lg:col-span-2">
+          <div class="flex items-center gap-2">
+            <button
+              :for={filter <- environment_filters()}
+              type="button"
+              phx-click="set_filter"
+              phx-value-filter={filter.value}
+              class={[
+                "console-button px-3 text-xs",
+                if(@environment_filter == filter.value,
+                  do: "console-button-primary",
+                  else: "console-button-secondary"
+                )
+              ]}
+            >
+              {filter.label}
+            </button>
+
+            <.link
+              patch={~p"/console/environments"}
+              class="console-button console-button-ghost ml-auto px-3 text-xs"
+            >
+              <.icon name="hero-plus" class="size-3" /> New
+            </.link>
           </div>
-          <div class="grid gap-4 rounded-[1.5rem] border border-white/10 bg-white/5 p-5 text-sm text-emerald-50/90 sm:grid-cols-3 lg:grid-cols-1 xl:grid-cols-3">
-            <.metric_card label="Active" value={active_environment_count(@environments)} />
-            <.metric_card label="Archived" value={archived_environment_count(@environments)} />
-            <.metric_card
-              label="Open Network"
-              value={unrestricted_environment_count(@environments)}
+
+          <div :if={filtered_environments(@environments, @environment_filter) == []}>
+            <.empty_state
+              title="No environments"
+              description="Create a template or widen the filter."
             />
           </div>
-        </div>
-      </section>
 
-      <div class="grid gap-8 xl:grid-cols-[minmax(0,0.92fr)_minmax(0,1.08fr)]">
-        <section class="rounded-[2rem] border border-neutral-200 bg-white p-6 shadow-sm">
-          <div class="flex flex-wrap items-start justify-between gap-4">
-            <div>
-              <p class="text-xs font-semibold uppercase tracking-[0.24em] text-emerald-700">
-                Catalog
-              </p>
-              <h2 class="mt-2 text-xl font-semibold tracking-tight text-neutral-950">
-                Saved environments
-              </h2>
-              <p class="mt-1 text-sm leading-6 text-neutral-600">
-                Templates stay reusable across sessions. Archived templates remain visible but read-only.
-              </p>
-            </div>
-            <.button
-              patch={~p"/console/environments"}
-              class="rounded-full bg-neutral-900 px-5 text-white hover:bg-neutral-800"
-            >
-              New template
-            </.button>
-          </div>
+          <.link
+            :for={environment <- filtered_environments(@environments, @environment_filter)}
+            id={"environment-card-#{environment.id}"}
+            patch={~p"/console/environments/#{environment.id}/edit"}
+            class={[
+              "block rounded-[8px] border p-4 text-left transition min-h-[56px]",
+              selected_environment?(@selected_environment, environment) &&
+                "border-[var(--session)]/40 bg-[var(--session-soft)]",
+              !selected_environment?(@selected_environment, environment) &&
+                "border-[var(--border-subtle)] bg-[var(--panel-bg)] hover:bg-[var(--panel-muted)]"
+            ]}
+          >
+            <div class="flex items-start gap-3">
+              <span class="mt-0.5 inline-flex shrink-0 text-[var(--session)]">
+                <.icon name="hero-server-stack" class="size-4" />
+              </span>
 
-          <div id="environment-list" class="mt-6 space-y-6">
-            <div
-              :if={active_environments(@environments) == []}
-              class="rounded-[1.5rem] border border-dashed border-neutral-300 bg-neutral-50 px-5 py-10 text-center text-sm text-neutral-500"
-            >
-              No environments yet. Create the first template on the right.
-            </div>
-
-            <div :if={active_environments(@environments) != []} class="space-y-3">
-              <p class="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">
-                Active
-              </p>
-              <div
-                :for={environment <- active_environments(@environments)}
-                class={environment_card_class(environment, @selected_environment)}
-              >
-                <div class="flex items-start justify-between gap-4">
-                  <div class="space-y-2">
-                    <div class="flex flex-wrap items-center gap-2">
-                      <p class="text-base font-semibold text-neutral-950">{environment.name}</p>
-                      <span class={networking_badge_class(environment)}>
-                        {networking_label(environment)}
-                      </span>
-                    </div>
-                    <p class="text-sm leading-6 text-neutral-600">
-                      {environment.description || "No description yet."}
-                    </p>
-                    <p class="text-xs uppercase tracking-[0.18em] text-neutral-400">
-                      Updated {ConsoleHelpers.format_timestamp(environment.updated_at)}
-                    </p>
-                  </div>
-                  <.button
-                    patch={~p"/console/environments/#{environment.id}/edit"}
-                    class="rounded-full border border-neutral-300 bg-white px-4 text-neutral-800 hover:border-emerald-300 hover:bg-emerald-50"
-                  >
-                    Edit
-                  </.button>
+              <div class="min-w-0 flex-1">
+                <div class="flex flex-wrap items-center gap-2">
+                  <p class="text-sm font-medium text-[var(--text-strong)]">{environment.name}</p>
+                  <.status_badge :if={environment.archived_at} status="archived" size="small" />
                 </div>
+
+                <div class="mt-1 flex flex-wrap items-center gap-2">
+                  <.status_badge status={networking_label(environment)} size="small" />
+                  <span class="text-[10px] text-[var(--text-muted)]">
+                    {ConsoleHelpers.format_timestamp(environment.updated_at)}
+                  </span>
+                </div>
+
+                <p :if={environment.description} class="mt-1 text-xs text-[var(--text-muted)]">
+                  {environment.description}
+                </p>
               </div>
             </div>
-
-            <div :if={archived_environments(@environments) != []} class="space-y-3">
-              <p class="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">
-                Archived
-              </p>
-              <div
-                :for={environment <- archived_environments(@environments)}
-                class={environment_card_class(environment, @selected_environment)}
-              >
-                <div class="flex items-start justify-between gap-4">
-                  <div class="space-y-2">
-                    <div class="flex flex-wrap items-center gap-2">
-                      <p class="text-base font-semibold text-neutral-950">{environment.name}</p>
-                      <span class="inline-flex items-center rounded-full bg-neutral-900 px-2.5 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-white">
-                        Archived
-                      </span>
-                    </div>
-                    <p class="text-sm leading-6 text-neutral-600">
-                      {environment.description || "No description yet."}
-                    </p>
-                    <p class="text-xs uppercase tracking-[0.18em] text-neutral-400">
-                      Archived {ConsoleHelpers.format_timestamp(environment.archived_at)}
-                    </p>
-                  </div>
-                  <.button
-                    patch={~p"/console/environments/#{environment.id}/edit"}
-                    class="rounded-full border border-neutral-300 bg-white px-4 text-neutral-800 hover:border-neutral-400 hover:bg-neutral-50"
-                  >
-                    View
-                  </.button>
-                </div>
-              </div>
-            </div>
-          </div>
+          </.link>
         </section>
 
-        <section class="rounded-[2rem] border border-neutral-200 bg-white p-6 shadow-sm">
-          <div class="flex flex-wrap items-start justify-between gap-4">
-            <div>
-              <p class="text-xs font-semibold uppercase tracking-[0.24em] text-emerald-700">
-                Editor
-              </p>
-              <h2 class="mt-2 text-xl font-semibold tracking-tight text-neutral-950">
-                {environment_form_title(@selected_environment)}
-              </h2>
-              <p class="mt-1 text-sm leading-6 text-neutral-600">
-                Environments always target the cloud runtime contract. The only mutable runtime switch in v1 is networking.
-              </p>
-            </div>
+        <section class="lg:col-span-3">
+          <div class="rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-bg)] p-5 space-y-4">
             <div
-              :if={@selected_environment}
-              class="rounded-[1.25rem] border border-neutral-200 bg-neutral-50 px-4 py-3 text-sm text-neutral-600"
+              :if={@selected_environment && @selected_environment.archived_at}
+              id="environment-read-only-note"
+              class="rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-muted)] px-3 py-2 text-xs text-[var(--text-muted)]"
             >
-              <p class="font-medium text-neutral-900">Template ID</p>
-              <p class="mt-1 font-mono text-xs">{@selected_environment.id}</p>
+              This environment is archived and read-only.
             </div>
-          </div>
 
-          <div
-            :if={@selected_environment && @selected_environment.archived_at}
-            id="environment-read-only-note"
-            class="mt-6 rounded-[1.5rem] border border-amber-200 bg-amber-50 px-5 py-4 text-sm leading-6 text-amber-950"
-          >
-            This environment is archived. The saved template stays available for historical sessions, but edits are locked.
-          </div>
+            <h2 class="text-sm font-semibold text-[var(--text-strong)]">
+              {if @selected_environment do
+                if @selected_environment.archived_at,
+                  do: @environment_form_params["name"],
+                  else: "Edit: #{@environment_form_params["name"]}"
+              else
+                "New Environment"
+              end}
+            </h2>
 
-          <div
-            :if={@environment_errors != []}
-            id="environment-error-list"
-            class="mt-6 rounded-[1.5rem] border border-rose-200 bg-rose-50 px-5 py-4 text-sm text-rose-900"
-          >
-            <p class="font-semibold">Environment could not be saved.</p>
-            <p :for={error <- @environment_errors} class="mt-2">{error}</p>
-          </div>
+            <div
+              :if={@environment_errors != []}
+              id="environment-error-list"
+              class="rounded-[8px] border border-[var(--danger)]/20 bg-[var(--danger-soft)] px-4 py-3 text-sm text-[var(--text-strong)]"
+            >
+              <p :for={error <- @environment_errors}>{error}</p>
+            </div>
 
-          <.form
-            for={@environment_form}
-            id="environment-form"
-            class="mt-6 space-y-6"
-            phx-change="validate_environment"
-            phx-submit="save_environment"
-          >
-            <div class="grid gap-5 md:grid-cols-2">
-              <.input
-                field={@environment_form[:name]}
-                label="Environment name"
-                placeholder="quickstart-env"
-                disabled={environment_read_only?(@selected_environment)}
-              />
-              <div class="rounded-[1.5rem] border border-neutral-200 bg-neutral-50 px-4 py-3">
-                <p class="text-sm font-medium text-neutral-900">Runtime type</p>
-                <p class="mt-2 inline-flex items-center rounded-full bg-neutral-900 px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-white">
-                  cloud
-                </p>
-                <p class="mt-3 text-sm leading-6 text-neutral-600">
-                  Anthropic-compatible container templates map to the `cloud` contract in v1.
-                </p>
+            <.form
+              for={@environment_form}
+              id="environment-form"
+              class="space-y-4"
+              phx-change="validate_environment"
+              phx-submit="save_environment"
+            >
+              <div>
+                <.input
+                  field={@environment_form[:name]}
+                  label="Name"
+                  placeholder="Environment name"
+                  disabled={environment_read_only?(@selected_environment)}
+                />
               </div>
-              <.input
-                field={@environment_form[:description]}
-                type="textarea"
-                label="Description"
-                rows="4"
-                placeholder="Reusable runtime for internal assistants."
-                disabled={environment_read_only?(@selected_environment)}
-              />
-              <div class="rounded-[1.5rem] border border-neutral-200 bg-neutral-50 p-4">
+
+              <div>
+                <.input
+                  field={@environment_form[:description]}
+                  type="textarea"
+                  label="Description"
+                  rows="2"
+                  placeholder="What is this environment for?"
+                  disabled={environment_read_only?(@selected_environment)}
+                />
+              </div>
+
+              <div>
+                <label class="mb-1 block text-sm font-medium leading-6 text-zinc-950 dark:text-zinc-100">
+                  Runtime Type
+                </label>
+                <input
+                  type="text"
+                  value="cloud"
+                  disabled
+                  class="mt-1 block w-full rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-muted)] px-3 py-2.5 text-sm text-[var(--text-muted)] outline-none"
+                />
+              </div>
+
+              <div>
                 <.input
                   field={@environment_form[:networking_type]}
                   type="select"
@@ -326,95 +286,48 @@ defmodule JidoManagedAgentsWeb.EnvironmentConsoleLive do
                   options={networking_options()}
                   disabled={environment_read_only?(@selected_environment)}
                 />
-                <p class="mt-3 text-sm leading-6 text-neutral-600">
-                  Restricted keeps network access narrow. Unrestricted is best for agents that need open third-party APIs.
+                <p class="mt-1.5 text-[11px] text-[var(--text-muted)]">
+                  <%= if @environment_form_params["networking_type"] == "restricted" do %>
+                    No outbound network. Safe for untrusted configs.
+                  <% else %>
+                    Full outbound access. Use with trusted configs only.
+                  <% end %>
                 </p>
               </div>
-            </div>
 
-            <div class="rounded-[1.5rem] border border-neutral-200 bg-neutral-50 p-4">
-              <.input
-                field={@environment_form[:metadata_json]}
-                type="textarea"
-                label="Metadata JSON"
-                rows="8"
-                placeholder={"{\n  \"team\": \"platform\"\n}"}
-                disabled={environment_read_only?(@selected_environment)}
-              />
-              <p class="mt-2 text-sm leading-6 text-neutral-500">
-                Optional JSON for labels and downstream routing. The editor expects an object.
-              </p>
-            </div>
+              <div>
+                <.input
+                  field={@environment_form[:metadata_json]}
+                  type="textarea"
+                  label="Metadata JSON"
+                  rows="3"
+                  disabled={environment_read_only?(@selected_environment)}
+                />
+              </div>
 
-            <div class="flex flex-wrap gap-3">
-              <.button
-                id="environment-save-button"
-                class="rounded-full bg-emerald-600 px-5 text-white hover:bg-emerald-500 disabled:border disabled:border-neutral-200 disabled:bg-neutral-100 disabled:text-neutral-400"
-                disabled={environment_read_only?(@selected_environment)}
-              >
-                {environment_submit_label(@selected_environment)}
-              </.button>
-              <button
-                :if={@selected_environment && !@selected_environment.archived_at}
-                id="environment-archive-button"
-                type="button"
-                phx-click="archive_environment"
-                class="rounded-full border border-amber-200 bg-amber-50 px-5 py-2 text-sm font-medium text-amber-950 transition hover:bg-amber-100"
-              >
-                Archive
-              </button>
-              <.button
-                :if={@selected_environment}
-                patch={~p"/console/environments"}
-                class="rounded-full border border-neutral-300 bg-white px-5 text-neutral-800 hover:border-neutral-400 hover:bg-neutral-50"
-              >
-                Start new template
-              </.button>
-            </div>
-          </.form>
+              <div :if={!environment_read_only?(@selected_environment)} class="flex flex-wrap gap-2">
+                <.button
+                  id="environment-save-button"
+                  class="console-button console-button-primary"
+                >
+                  {if @selected_environment, do: "Save Template", else: "Create Template"}
+                </.button>
+
+                <button
+                  :if={@selected_environment}
+                  id="environment-archive-button"
+                  type="button"
+                  phx-click="archive_environment"
+                  class="console-button console-button-secondary"
+                >
+                  Archive
+                </button>
+              </div>
+            </.form>
+          </div>
         </section>
       </div>
     </Layouts.app>
-    """
-  end
-
-  attr :label, :string, required: true
-  attr :value, :integer, required: true
-
-  defp metric_card(assigns) do
-    ~H"""
-    <div>
-      <p class="text-xs uppercase tracking-[0.2em] text-emerald-100/70">{@label}</p>
-      <p class="mt-2 text-3xl font-semibold tracking-tight">{@value}</p>
-    </div>
-    """
-  end
-
-  attr :label, :string, required: true
-  attr :active, :boolean, default: false
-  attr :navigate, :string, default: nil
-
-  defp console_tab(%{navigate: nil} = assigns) do
-    ~H"""
-    <span class="inline-flex items-center rounded-full border border-white/15 bg-white/12 px-4 py-2 text-sm font-medium text-white">
-      {@label}
-    </span>
-    """
-  end
-
-  defp console_tab(assigns) do
-    ~H"""
-    <.link
-      navigate={@navigate}
-      class={[
-        "inline-flex items-center rounded-full px-4 py-2 text-sm font-medium transition",
-        @active && "border border-white/15 bg-white/12 text-white",
-        !@active &&
-          "border border-white/10 bg-black/10 text-white/75 hover:bg-white/10 hover:text-white"
-      ]}
-    >
-      {@label}
-    </.link>
     """
   end
 
@@ -543,46 +456,16 @@ defmodule JidoManagedAgentsWeb.EnvironmentConsoleLive do
     Enum.filter(environments, &match?(%DateTime{}, &1.archived_at))
   end
 
+  defp filtered_environments(environments, "active"), do: active_environments(environments)
+  defp filtered_environments(environments, "archived"), do: archived_environments(environments)
+  defp filtered_environments(environments, _filter), do: environments
+
   defp active_environment_count(environments), do: length(active_environments(environments))
   defp archived_environment_count(environments), do: length(archived_environments(environments))
-
-  defp unrestricted_environment_count(environments) do
-    environments
-    |> active_environments()
-    |> Enum.count(&(networking_label(&1) == "unrestricted"))
-  end
 
   defp networking_label(environment) do
     get_in(environment.config || %{}, ["networking", "type"]) || "restricted"
   end
-
-  defp networking_badge_class(environment) do
-    case networking_label(environment) do
-      "unrestricted" ->
-        "inline-flex items-center rounded-full bg-emerald-100 px-2.5 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-emerald-900"
-
-      _other ->
-        "inline-flex items-center rounded-full bg-sky-100 px-2.5 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-sky-900"
-    end
-  end
-
-  defp environment_card_class(environment, selected_environment) do
-    selected? = selected_environment && selected_environment.id == environment.id
-
-    [
-      "rounded-[1.5rem] border p-4 transition",
-      if(selected?,
-        do: "border-emerald-300 bg-emerald-50/70 shadow-sm shadow-emerald-100",
-        else: "border-neutral-200 bg-white hover:border-emerald-200 hover:bg-emerald-50/40"
-      )
-    ]
-  end
-
-  defp environment_form_title(nil), do: "Create environment"
-  defp environment_form_title(_environment), do: "Edit environment"
-
-  defp environment_submit_label(nil), do: "Create environment"
-  defp environment_submit_label(_environment), do: "Save environment"
 
   defp environment_saved_message(nil), do: "Environment created."
   defp environment_saved_message(_environment), do: "Environment updated."
@@ -591,10 +474,22 @@ defmodule JidoManagedAgentsWeb.EnvironmentConsoleLive do
   defp environment_read_only?(%Environment{archived_at: %DateTime{}}), do: true
   defp environment_read_only?(%Environment{}), do: false
 
+  defp selected_environment?(nil, _environment), do: false
+  defp selected_environment?(%Environment{id: id}, %Environment{id: id}), do: true
+  defp selected_environment?(_selected, _environment), do: false
+
   defp networking_options do
     [
       {"Restricted", "restricted"},
       {"Unrestricted", "unrestricted"}
+    ]
+  end
+
+  defp environment_filters do
+    [
+      %{label: "All", value: "all"},
+      %{label: "Active", value: "active"},
+      %{label: "Archived", value: "archived"}
     ]
   end
 end

--- a/lib/jido_managed_agents_web/live/overview_live.ex
+++ b/lib/jido_managed_agents_web/live/overview_live.ex
@@ -1,0 +1,271 @@
+defmodule JidoManagedAgentsWeb.OverviewLive do
+  use JidoManagedAgentsWeb, :live_view
+
+  on_mount {JidoManagedAgentsWeb.LiveUserAuth, :live_user_required}
+
+  alias JidoManagedAgentsWeb.ConsoleData
+  alias JidoManagedAgentsWeb.ConsoleHelpers
+
+  @impl true
+  def mount(_params, _session, socket) do
+    actor = socket.assigns.current_user
+    agents = ConsoleData.list_agents(actor)
+    environments = ConsoleData.list_environments(actor)
+    sessions = ConsoleData.list_sessions(actor, limit: 10)
+    pending_sessions = Enum.filter(sessions, &ConsoleHelpers.requires_action?(&1.stop_reason))
+
+    running_sessions_count =
+      Enum.count(sessions, fn session ->
+        to_string(session.status) in ["running", "idle"] or
+          ConsoleHelpers.requires_action?(session.stop_reason)
+      end)
+
+    {:ok,
+     socket
+     |> assign_new(:current_scope, fn -> nil end)
+     |> assign(:page_title, "Overview")
+     |> assign(:agents, agents)
+     |> assign(:environments, environments)
+     |> assign(:sessions, sessions)
+     |> assign(:pending_sessions, pending_sessions)
+     |> assign(:running_sessions_count, running_sessions_count)
+     |> assign(:activities, activity_items(agents, environments, sessions))
+     |> assign(:pending_count, length(pending_sessions))}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app
+      flash={@flash}
+      current_scope={@current_scope}
+      current_user={@current_user}
+      section={:overview}
+      pending_count={@pending_count}
+    >
+      <.page_header
+        title="Overview"
+        description="A compact operator view across agents, sessions, environments, and the work that still needs input."
+      >
+        <:actions>
+          <.link navigate={~p"/console/agents/new"} class="console-button console-button-primary">
+            <.icon name="hero-plus" class="size-4" /> New Agent
+          </.link>
+        </:actions>
+      </.page_header>
+
+      <section class="console-grid-4">
+        <.kpi_card
+          label="Agents"
+          value={Integer.to_string(Enum.count(@agents, &is_nil(&1.archived_at)))}
+          icon="hero-cpu-chip"
+        />
+        <.kpi_card
+          label="Active Sessions"
+          value={Integer.to_string(@running_sessions_count)}
+          icon="hero-bolt"
+          accent="text-[var(--session)]"
+        />
+        <.kpi_card
+          label="Needs Input"
+          value={Integer.to_string(length(@pending_sessions))}
+          icon="hero-exclamation-circle"
+          accent={if(@pending_sessions != [], do: "text-[var(--accent)]", else: nil)}
+        />
+        <.kpi_card
+          label="Environments"
+          value={Integer.to_string(Enum.count(@environments, &is_nil(&1.archived_at)))}
+          icon="hero-server-stack"
+        />
+      </section>
+
+      <section class="console-grid-2">
+        <div class="space-y-6">
+          <section class="console-panel space-y-4">
+            <div class="space-y-1">
+              <p class="console-label">Pending Approvals</p>
+              <h2 class="text-lg font-semibold text-[var(--text-strong)]">Sessions waiting on you</h2>
+            </div>
+
+            <div :if={@pending_sessions == []}>
+              <.empty_state
+                title="Nothing blocked"
+                description="All recent sessions can keep moving without operator input."
+              />
+            </div>
+
+            <div :if={@pending_sessions != []} class="space-y-3">
+              <.link
+                :for={session <- @pending_sessions}
+                navigate={~p"/console/sessions/#{session.id}"}
+                class="console-list-link"
+              >
+                <div class="console-list-row">
+                  <div class="min-w-0 space-y-2">
+                    <div class="flex flex-wrap items-center gap-2">
+                      <p class="truncate text-sm font-semibold text-[var(--text-strong)]">
+                        {session.title || ConsoleHelpers.short_id(session.id)}
+                      </p>
+                      <.status_badge status="needs_input" />
+                    </div>
+                    <p class="console-list-meta">
+                      {session.agent.name} · {ConsoleHelpers.session_model(session)}
+                    </p>
+                  </div>
+                  <.icon
+                    name="hero-arrow-right"
+                    class="mt-1 size-4 shrink-0 text-[var(--text-faint)]"
+                  />
+                </div>
+              </.link>
+            </div>
+          </section>
+
+          <section class="console-panel space-y-4">
+            <div class="space-y-1">
+              <p class="console-label">Quick Actions</p>
+              <h2 class="text-lg font-semibold text-[var(--text-strong)]">
+                Move straight to the common paths
+              </h2>
+            </div>
+
+            <div class="grid gap-3 sm:grid-cols-2">
+              <.link
+                navigate={~p"/console/agents/new"}
+                class="console-button console-button-secondary"
+              >
+                <.icon name="hero-plus" class="size-4" /> Create Agent
+              </.link>
+              <.link navigate={~p"/console/sessions"} class="console-button console-button-secondary">
+                <.icon name="hero-bolt" class="size-4" /> Review Sessions
+              </.link>
+              <.link
+                :if={@pending_sessions != []}
+                navigate={~p"/console/sessions/#{hd(@pending_sessions).id}"}
+                class="console-button console-button-secondary sm:col-span-2"
+              >
+                <.icon name="hero-arrow-top-right-on-square" class="size-4" />
+                Open Latest Pending Session
+              </.link>
+            </div>
+          </section>
+        </div>
+
+        <section class="space-y-6">
+          <section class="console-panel space-y-4">
+            <div class="space-y-1">
+              <p class="console-label">Recent Sessions</p>
+              <h2 class="text-lg font-semibold text-[var(--text-strong)]">Latest traces</h2>
+            </div>
+
+            <div :if={@sessions == []}>
+              <.empty_state
+                title="No sessions yet"
+                description="Launch a session from an agent detail page or the builder to see it here."
+              />
+            </div>
+
+            <div :if={@sessions != []} class="space-y-3">
+              <.link
+                :for={session <- @sessions}
+                navigate={~p"/console/sessions/#{session.id}"}
+                class="console-list-link"
+              >
+                <div class="space-y-2">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <p class="truncate text-sm font-semibold text-[var(--text-strong)]">
+                      {session.title || ConsoleHelpers.short_id(session.id)}
+                    </p>
+                    <.status_badge status={
+                      if(ConsoleHelpers.requires_action?(session.stop_reason),
+                        do: "needs_input",
+                        else: session.status
+                      )
+                    } />
+                  </div>
+                  <p class="console-list-meta">
+                    {session.agent.name} · {length(session.threads || [])} thread(s) · {ConsoleHelpers.format_timestamp(
+                      session.created_at
+                    )}
+                  </p>
+                </div>
+              </.link>
+            </div>
+          </section>
+
+          <section class="console-panel space-y-4">
+            <div class="space-y-1">
+              <p class="console-label">Activity</p>
+              <h2 class="text-lg font-semibold text-[var(--text-strong)]">Recent changes</h2>
+            </div>
+
+            <div class="space-y-3">
+              <div
+                :for={activity <- @activities}
+                class="flex items-start gap-3 rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-muted)] p-3"
+              >
+                <span class={activity_dot_class(activity.kind)}></span>
+                <div class="min-w-0">
+                  <.link
+                    :if={activity[:path]}
+                    navigate={activity.path}
+                    class="text-sm font-medium text-[var(--text-strong)] hover:underline"
+                  >
+                    {activity.message}
+                  </.link>
+                  <p :if={!activity[:path]} class="text-sm font-medium text-[var(--text-strong)]">
+                    {activity.message}
+                  </p>
+                  <p class="console-list-meta">
+                    {ConsoleHelpers.format_timestamp(activity.timestamp)}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </section>
+        </section>
+      </section>
+    </Layouts.app>
+    """
+  end
+
+  defp activity_items(agents, environments, sessions) do
+    session_items =
+      Enum.map(Enum.take(sessions, 4), fn session ->
+        %{
+          kind: :session,
+          message: "#{session.title || "Session #{ConsoleHelpers.short_id(session.id)}"} updated",
+          timestamp: session.updated_at,
+          path: ~p"/console/sessions/#{session.id}"
+        }
+      end)
+
+    agent_items =
+      Enum.map(Enum.take(agents, 3), fn agent ->
+        %{
+          kind: :agent,
+          message: "#{agent.name} saved",
+          timestamp: agent.updated_at,
+          path: ~p"/console/agents/#{agent.id}"
+        }
+      end)
+
+    environment_items =
+      Enum.map(Enum.take(environments, 2), fn environment ->
+        %{
+          kind: :environment,
+          message: "#{environment.name} available",
+          timestamp: environment.updated_at,
+          path: ~p"/console/environments/#{environment.id}/edit"
+        }
+      end)
+
+    (session_items ++ agent_items ++ environment_items)
+    |> Enum.sort_by(& &1.timestamp, {:desc, DateTime})
+    |> Enum.take(6)
+  end
+
+  defp activity_dot_class(:agent), do: "mt-2 size-2 rounded-full bg-[var(--accent)]"
+  defp activity_dot_class(:environment), do: "mt-2 size-2 rounded-full bg-[var(--success)]"
+  defp activity_dot_class(_kind), do: "mt-2 size-2 rounded-full bg-[var(--session)]"
+end

--- a/lib/jido_managed_agents_web/live/session_observability_live.ex
+++ b/lib/jido_managed_agents_web/live/session_observability_live.ex
@@ -28,18 +28,31 @@ defmodule JidoManagedAgentsWeb.SessionObservabilityLive do
      socket
      |> assign_new(:current_scope, fn -> nil end)
      |> assign(:page_title, "Sessions")
+     |> assign(:all_sessions, [])
      |> assign(:sessions, [])
+     |> assign(:session_filters, default_session_filters())
+     |> assign(:session_filter_form, to_form(default_session_filters(), as: :filters))
+     |> assign(:view_tab, "transcript")
+     |> assign(:debug_tab, "timeline")
+     |> assign(:selected_event_id, nil)
+     |> assign(:composer_params, default_composer_params())
+     |> assign(:composer_form, to_form(default_composer_params(), as: :composer))
+     |> assign(:pending_count, 0)
      |> assign_detail(nil, nil)}
   end
 
   @impl true
   def handle_params(_params, _uri, %{assigns: %{live_action: :index}} = socket) do
     actor = socket.assigns.current_user
+    sessions = list_sessions(actor)
+    filters = socket.assigns.session_filters
 
     {:noreply,
      socket
      |> assign(:page_title, "Sessions")
-     |> assign(:sessions, list_sessions(actor))
+     |> assign(:all_sessions, sessions)
+     |> assign(:sessions, filter_sessions(sessions, filters))
+     |> assign(:pending_count, count_requires_action(sessions))
      |> assign_detail(nil, nil)}
   end
 
@@ -52,7 +65,12 @@ defmodule JidoManagedAgentsWeb.SessionObservabilityLive do
         {:noreply,
          socket
          |> assign(:page_title, detail_title(detail.session))
+         |> assign(:pending_count, pending_session_count(actor))
          |> assign(:sessions, [])
+         |> assign(:all_sessions, [])
+         |> assign(:selected_event_id, nil)
+         |> assign(:composer_params, default_composer_params())
+         |> assign(:composer_form, to_form(default_composer_params(), as: :composer))
          |> assign_detail(detail, selected_thread_id)}
 
       {:error, :invalid_thread} ->
@@ -113,457 +131,873 @@ defmodule JidoManagedAgentsWeb.SessionObservabilityLive do
 
   def handle_event("confirm_tool", _params, socket), do: {:noreply, socket}
 
+  def handle_event("filter_sessions", %{"filters" => params}, socket) do
+    filters = normalize_session_filters(params)
+
+    {:noreply,
+     socket
+     |> assign(:session_filters, filters)
+     |> assign(:session_filter_form, to_form(filters, as: :filters))
+     |> assign(:sessions, filter_sessions(socket.assigns.all_sessions, filters))}
+  end
+
+  def handle_event("set_view", %{"view" => view}, socket) when view in ["transcript", "debug"] do
+    {:noreply, assign(socket, :view_tab, view)}
+  end
+
+  def handle_event("set_debug_tab", %{"tab" => tab}, socket)
+      when tab in ["timeline", "tools", "metrics", "raw"] do
+    {:noreply, assign(socket, :debug_tab, tab)}
+  end
+
+  def handle_event("select_event", %{"id" => event_id}, socket) do
+    next_id = if socket.assigns.selected_event_id == event_id, do: nil, else: event_id
+    {:noreply, assign(socket, :selected_event_id, next_id)}
+  end
+
+  def handle_event("validate_composer", %{"composer" => params}, socket) do
+    params = normalize_composer_params(params)
+
+    {:noreply,
+     socket
+     |> assign(:composer_params, params)
+     |> assign(:composer_form, to_form(params, as: :composer))}
+  end
+
+  def handle_event(
+        "send_message",
+        %{"composer" => params},
+        %{assigns: %{session: %Session{} = session}} = socket
+      ) do
+    actor = socket.assigns.current_user
+    params = normalize_composer_params(params)
+
+    with message when message != "" <- String.trim(params["prompt"]),
+         {:ok, events} <- normalized_user_message(message, session, actor),
+         {:ok, _appended_events} <- SessionEventLog.append_user_events(session, events, actor),
+         {:ok, _run_result} <- safe_run_session(session.id, actor),
+         {:ok, refreshed_detail} <-
+           load_detail(session.id, socket.assigns.selected_thread_id, actor) do
+      {:noreply,
+       socket
+       |> assign(:page_title, detail_title(refreshed_detail.session))
+       |> assign(:composer_params, default_composer_params())
+       |> assign(:composer_form, to_form(default_composer_params(), as: :composer))
+       |> assign(:pending_count, pending_session_count(actor))
+       |> assign_detail(refreshed_detail, socket.assigns.selected_thread_id)}
+    else
+      "" ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "Enter a message before sending.")
+         |> assign(:composer_params, params)
+         |> assign(:composer_form, to_form(params, as: :composer))}
+
+      {:error, error} ->
+        {:noreply, put_flash(socket, :error, ConsoleHelpers.error_message(error))}
+    end
+  end
+
+  def handle_event("send_message", _params, socket), do: {:noreply, socket}
+
   @impl true
   def render(assigns) do
+    assigns =
+      assigns
+      |> assign(
+        :selected_event,
+        selected_event(assigns.display_events, assigns.selected_event_id)
+      )
+      |> assign(:can_compose, session_composable?(assigns[:session]))
+
     ~H"""
     <Layouts.app
       flash={@flash}
       current_scope={@current_scope}
       current_user={@current_user}
-      main_class="px-4 py-8 sm:px-6 lg:px-8"
-      container_class="mx-auto max-w-7xl space-y-8"
+      section={:sessions}
+      pending_count={@pending_count}
     >
       <%= if @live_action == :index do %>
-        <section class="overflow-hidden rounded-[2rem] border border-amber-200/70 bg-[radial-gradient(circle_at_top_left,_rgba(245,158,11,0.18),_transparent_38%),linear-gradient(135deg,_#111827,_#172554_58%,_#1f2937)] text-white shadow-2xl shadow-amber-950/20">
-          <div class="grid gap-8 px-6 py-8 lg:grid-cols-[minmax(0,1.18fr)_minmax(0,0.82fr)] lg:px-10">
-            <div class="space-y-4">
-              <p class="text-xs font-semibold uppercase tracking-[0.28em] text-amber-200">
-                Session Observability
-              </p>
-              <h1 class="max-w-3xl text-3xl font-semibold tracking-tight sm:text-4xl">
-                Sessions
-              </h1>
-              <p class="max-w-2xl text-sm leading-6 text-amber-50/80">
-                Inspect recent runs without leaving the dashboard. Trace the exact event stream, provider usage, tool activity, and any blocked approvals before you touch the database.
-              </p>
-              <div class="flex flex-wrap gap-3 pt-2">
-                <.console_tab navigate={~p"/console/agents/new"} label="Agents" />
-                <.console_tab navigate={~p"/console/environments"} label="Environments" />
-                <.console_tab navigate={~p"/console/vaults"} label="Vaults" />
-                <.console_tab navigate={nil} label="Sessions" />
-              </div>
-            </div>
-            <div class="grid gap-4 rounded-[1.5rem] border border-white/10 bg-white/5 p-5 text-sm text-amber-50/90 sm:grid-cols-3 lg:grid-cols-1 xl:grid-cols-3">
-              <.metric_card label="Sessions" value={length(@sessions)} />
-              <.metric_card label="Running" value={count_sessions(@sessions, "running")} />
-              <.metric_card label="Needs Input" value={count_requires_action(@sessions)} />
-            </div>
-          </div>
+        <.page_header
+          title="Sessions"
+          description="Browse active traces, filter down to the runs that need attention, and open a transcript-first detail view when you need to interact with the agent."
+        >
+          <:actions>
+            <.link navigate={~p"/console/agents"} class="console-button console-button-secondary">
+              <.icon name="hero-cpu-chip" class="size-4" /> Agents
+            </.link>
+          </:actions>
+        </.page_header>
+
+        <section class="console-grid-3">
+          <.kpi_card
+            label="Sessions"
+            value={Integer.to_string(length(@all_sessions))}
+            icon="hero-bolt"
+          />
+          <.kpi_card
+            label="Running"
+            value={Integer.to_string(count_sessions(@all_sessions, "running"))}
+            icon="hero-play"
+            accent="text-[var(--session)]"
+          />
+          <.kpi_card
+            label="Needs Input"
+            value={Integer.to_string(count_requires_action(@all_sessions))}
+            icon="hero-exclamation-circle"
+            accent={
+              if(count_requires_action(@all_sessions) > 0, do: "text-[var(--accent)]", else: nil)
+            }
+          />
         </section>
 
-        <section class="rounded-[2rem] border border-neutral-200 bg-white p-6 shadow-sm">
-          <div class="flex flex-wrap items-start justify-between gap-4">
-            <div>
-              <p class="text-xs font-semibold uppercase tracking-[0.24em] text-amber-700">
-                Session List
-              </p>
-              <h2 class="mt-2 text-xl font-semibold tracking-tight text-neutral-950">
-                Recent traces
-              </h2>
-              <p class="mt-1 text-sm leading-6 text-neutral-600">
-                Status, model selection, and agent ownership stay visible at a glance so you can jump straight to the session that needs attention.
-              </p>
-            </div>
-          </div>
-
-          <div
-            :if={@sessions == []}
-            class="mt-6 rounded-[1.5rem] border border-dashed border-neutral-300 bg-neutral-50 px-5 py-10 text-center text-sm text-neutral-500"
+        <section class="console-panel space-y-4">
+          <.form
+            for={@session_filter_form}
+            id="session-filters"
+            class="flex flex-col gap-3 md:flex-row md:items-center"
+            phx-change="filter_sessions"
           >
-            No sessions yet. Launch a run from the agent builder to start collecting traces.
+            <div class="relative min-w-0 flex-1">
+              <span class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-faint)]">
+                <.icon name="hero-magnifying-glass" class="size-4" />
+              </span>
+              <input
+                type="text"
+                name="filters[search]"
+                value={@session_filters["search"]}
+                placeholder="Search sessions"
+                class="w-full rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-bg)] px-10 py-3 text-sm text-[var(--text-strong)] outline-none transition focus:border-[var(--border-strong)]"
+              />
+            </div>
+
+            <div class="flex flex-wrap gap-2">
+              <button
+                :for={filter <- session_status_filters()}
+                type="submit"
+                name="filters[status]"
+                value={filter.value}
+                class={[
+                  "console-button",
+                  if(@session_filters["status"] == filter.value,
+                    do: "console-button-primary",
+                    else: "console-button-secondary"
+                  )
+                ]}
+              >
+                {filter.label}
+              </button>
+            </div>
+          </.form>
+        </section>
+
+        <section class="space-y-3">
+          <div :if={@sessions == []}>
+            <.empty_state
+              title="No sessions matched"
+              description="Adjust the status filter or search term to widen the result set."
+            />
           </div>
 
-          <div :if={@sessions != []} id="session-list" class="mt-6 space-y-4">
-            <.link
-              :for={session <- @sessions}
-              id={"session-card-#{session.id}"}
-              navigate={~p"/console/sessions/#{session.id}"}
-              class="block rounded-[1.5rem] border border-neutral-200 bg-neutral-50/80 p-5 transition hover:border-amber-300 hover:bg-amber-50/60"
-            >
-              <div class="flex flex-wrap items-start justify-between gap-4">
-                <div class="space-y-3">
-                  <div class="flex flex-wrap items-center gap-2">
-                    <p class="text-base font-semibold text-neutral-950">
-                      {session.title || short_id(session.id)}
-                    </p>
-                    <span class={status_badge_class(session.status)}>
-                      {status_label(session.status)}
-                    </span>
-                    <span
-                      :if={requires_action?(session.stop_reason)}
-                      class="inline-flex items-center rounded-full bg-amber-100 px-2.5 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-amber-900"
-                    >
-                      Needs input
-                    </span>
-                  </div>
-                  <div class="grid gap-3 text-sm text-neutral-600 sm:grid-cols-2 xl:grid-cols-4">
-                    <p>
-                      <span class="font-medium text-neutral-900">Agent:</span>
-                      {session_agent_name(session)}
-                    </p>
-                    <p>
-                      <span class="font-medium text-neutral-900">Model:</span>
-                      {session_model(session)}
-                    </p>
-                    <p>
-                      <span class="font-medium text-neutral-900">Created:</span>
-                      {ConsoleHelpers.format_timestamp(session.created_at)}
-                    </p>
-                    <p>
-                      <span class="font-medium text-neutral-900">Trace:</span>
-                      {thread_summary(session)}
-                    </p>
-                  </div>
+          <.link
+            :for={session <- @sessions}
+            navigate={~p"/console/sessions/#{session.id}"}
+            id={"session-card-#{session.id}"}
+            class="console-list-link"
+          >
+            <div class="console-list-row">
+              <div class="min-w-0 space-y-2">
+                <div class="flex flex-wrap items-center gap-2">
+                  <p class="truncate text-sm font-semibold text-[var(--text-strong)]">
+                    {detail_title(session)}
+                  </p>
+                  <.status_badge status={session_status_badge(session)} />
                 </div>
-                <div class="inline-flex items-center gap-2 rounded-full border border-neutral-200 bg-white px-4 py-2 text-sm font-medium text-neutral-700">
-                  Inspect <.icon name="hero-arrow-right" class="size-4" />
-                </div>
+                <p class="console-copy">
+                  {session_agent_name(session)} · {session_model(session)} · {thread_summary(session)}
+                </p>
+                <p class="console-list-meta">
+                  {ConsoleHelpers.format_timestamp(session.created_at)}
+                </p>
               </div>
-            </.link>
-          </div>
+              <.icon name="hero-chevron-right" class="mt-1 size-4 shrink-0 text-[var(--text-faint)]" />
+            </div>
+          </.link>
         </section>
       <% else %>
-        <section
-          id="session-detail"
-          class="overflow-hidden rounded-[2rem] border border-cyan-200/70 bg-[radial-gradient(circle_at_top_left,_rgba(34,211,238,0.18),_transparent_40%),linear-gradient(135deg,_#082f49,_#0f172a_56%,_#164e63)] text-white shadow-2xl shadow-cyan-950/20"
-        >
-          <div class="grid gap-8 px-6 py-8 lg:grid-cols-[minmax(0,1.12fr)_minmax(0,0.88fr)] lg:px-10">
-            <div class="space-y-4">
-              <div class="flex flex-wrap items-center gap-3">
+        <section class="console-panel space-y-5">
+          <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div class="space-y-3">
+              <div class="flex flex-wrap items-center gap-2">
                 <.link
                   navigate={~p"/console/sessions"}
-                  class="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-2 text-sm font-medium text-cyan-50 transition hover:bg-white/15"
+                  class="console-button console-button-secondary"
                 >
-                  <.icon name="hero-arrow-left" class="size-4" /> Session list
+                  <.icon name="hero-arrow-left" class="size-4" /> Sessions
                 </.link>
-                <span class={detail_status_badge_class(@session.status)}>
-                  {status_label(@session.status)}
-                </span>
-                <span
-                  :if={@pending_confirmations != []}
-                  class="inline-flex items-center rounded-full bg-amber-300/90 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-amber-950"
-                >
-                  Awaiting approval
-                </span>
+                <.status_badge status={session_status_badge(@session)} />
+                <.status_badge :if={@pending_confirmations != []} status="needs_input" />
               </div>
-              <p class="text-xs font-semibold uppercase tracking-[0.28em] text-cyan-200">
-                Trace Detail
-              </p>
-              <h1 class="max-w-3xl text-3xl font-semibold tracking-tight sm:text-4xl">
-                {detail_title(@session)}
-              </h1>
-              <p class="max-w-2xl text-sm leading-6 text-cyan-50/80">
-                Agent <span class="font-medium text-white">{session_agent_name(@session)}</span>
-                on model <span class="font-medium text-white">{session_model(@session)}</span>.
-                Created {ConsoleHelpers.format_timestamp(@session.created_at)}.
-              </p>
-              <div class="flex flex-wrap gap-3 pt-2 text-sm text-cyan-50/85">
-                <span class="rounded-full border border-white/10 bg-white/5 px-3 py-1.5">
-                  Trace scope: {@selected_trace_label}
-                </span>
-                <span class="rounded-full border border-white/10 bg-white/5 px-3 py-1.5">
-                  Events: {length(@display_events)}
-                </span>
-                <span class="rounded-full border border-white/10 bg-white/5 px-3 py-1.5">
-                  Threads: {length(@threads)}
-                </span>
+              <div>
+                <h1 class="console-title">{detail_title(@session)}</h1>
+                <p class="console-copy">
+                  {session_agent_name(@session)} · {session_model(@session)} · {ConsoleHelpers.format_timestamp(
+                    @session.created_at
+                  )}
+                </p>
               </div>
             </div>
-            <div class="grid gap-4 rounded-[1.5rem] border border-white/10 bg-white/5 p-5 text-sm text-cyan-50/90 sm:grid-cols-3 lg:grid-cols-1 xl:grid-cols-3">
-              <%= if @metrics do %>
-                <.metric_card label="Input Tokens" value={format_metric(@metrics["input_tokens"])} />
-                <.metric_card
-                  label="Output Tokens"
-                  value={format_metric(@metrics["output_tokens"])}
-                />
-                <.metric_card label="Total Tokens" value={format_metric(@metrics["total_tokens"])} />
-              <% else %>
-                <.metric_card label="Input Tokens" value="Unavailable" />
-                <.metric_card label="Output Tokens" value="Unavailable" />
-                <.metric_card label="Total Tokens" value="Unavailable" />
-              <% end %>
-            </div>
-          </div>
-        </section>
 
-        <section
-          id="thread-traces"
-          class="rounded-[2rem] border border-neutral-200 bg-white p-6 shadow-sm"
-        >
-          <div class="flex flex-wrap items-start justify-between gap-4">
-            <div>
-              <p class="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-700">
-                Trace Scope
-              </p>
-              <h2 class="mt-2 text-xl font-semibold tracking-tight text-neutral-950">
-                Thread traces
-              </h2>
-              <p class="mt-1 text-sm leading-6 text-neutral-600">
-                Start with the aggregated session trace, then drill into one thread at a time when delegation is active.
-              </p>
+            <div class="console-grid-3 w-full max-w-xl">
+              <.kpi_card
+                label="Threads"
+                value={Integer.to_string(length(@threads))}
+                icon="hero-squares-2x2"
+              />
+              <.kpi_card
+                label="Events"
+                value={Integer.to_string(length(@display_events))}
+                icon="hero-list-bullet"
+              />
+              <.kpi_card
+                label="Tokens"
+                value={metric_value(@metrics, "total_tokens")}
+                icon="hero-chart-bar"
+                accent="text-[var(--session)]"
+              />
             </div>
           </div>
 
-          <div class="mt-6 flex flex-wrap gap-3">
-            <.trace_scope_button
-              id="trace-scope-all"
-              patch={trace_scope_path(@session, nil)}
-              active={is_nil(@selected_thread)}
-              label="All traces"
-            />
-            <.trace_scope_button
-              :for={thread <- @threads}
-              id={"trace-scope-thread-#{thread.id}"}
-              patch={trace_scope_path(@session, thread)}
-              active={selected_thread?(@selected_thread, thread)}
-              label={thread_scope_label(thread)}
-            />
-          </div>
-        </section>
-
-        <div class="grid gap-8 xl:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)]">
-          <div class="space-y-8">
-            <section
-              id="session-trace"
-              class="rounded-[2rem] border border-neutral-200 bg-white p-6 shadow-sm"
+          <div class="console-tabs">
+            <button
+              type="button"
+              phx-click="set_view"
+              phx-value-view="transcript"
+              class={["console-tab", @view_tab == "transcript" && "console-tab-active"]}
             >
-              <div class="flex flex-wrap items-start justify-between gap-4">
-                <div>
-                  <p class="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-700">
-                    Trace Timeline
-                  </p>
-                  <h2 class="mt-2 text-xl font-semibold tracking-tight text-neutral-950">
-                    Chronological events
-                  </h2>
-                  <p class="mt-1 text-sm leading-6 text-neutral-600">
-                    Ordered event flow across status changes, agent messages, tools, approvals, and thread hand-offs.
-                  </p>
-                </div>
-              </div>
+              Transcript
+            </button>
+            <button
+              type="button"
+              phx-click="set_view"
+              phx-value-view="debug"
+              class={["console-tab", @view_tab == "debug" && "console-tab-active"]}
+            >
+              Debug
+            </button>
+          </div>
+        </section>
 
-              <div
-                :if={@latest_error_event}
-                class="mt-6 rounded-[1.5rem] border border-rose-200 bg-rose-50 px-5 py-4 text-sm text-rose-900"
+        <div :if={@view_tab == "transcript"} class="space-y-6">
+          <section class="space-y-3">
+            <div class="space-y-1">
+              <p class="console-label">Thread traces</p>
+              <p class="console-copy">
+                Scope the transcript to the primary thread or drill into delegate work without leaving the session.
+              </p>
+            </div>
+
+            <div class="flex flex-wrap gap-2">
+              <.link
+                id="trace-scope-all"
+                patch={trace_scope_path(@session, nil)}
+                class={[
+                  "console-button",
+                  if(is_nil(@selected_thread),
+                    do: "console-button-primary",
+                    else: "console-button-secondary"
+                  )
+                ]}
               >
-                <p class="font-semibold">Latest error</p>
-                <p class="mt-2 leading-6">{timeline_summary(@latest_error_event)}</p>
+                All traces
+              </.link>
+              <.link
+                :for={thread <- @threads}
+                id={"trace-scope-thread-#{thread.id}"}
+                patch={trace_scope_path(@session, thread)}
+                class={[
+                  "console-button",
+                  if(selected_thread?(@selected_thread, thread),
+                    do: "console-button-primary",
+                    else: "console-button-secondary"
+                  )
+                ]}
+              >
+                {thread_scope_label(thread)}
+              </.link>
+            </div>
+          </section>
+
+          <section
+            :if={@latest_error_event}
+            class="console-panel border-[var(--danger)]/20 bg-[var(--danger-soft)]"
+          >
+            <div class="space-y-2">
+              <p class="console-label text-[var(--danger)]">Latest error</p>
+              <p class="text-sm font-semibold text-[var(--text-strong)]">
+                {timeline_summary(@latest_error_event)}
+              </p>
+            </div>
+          </section>
+
+          <section
+            :if={@pending_confirmations != []}
+            class="console-panel border-[var(--accent)]/20 bg-[var(--accent-soft)]"
+          >
+            <div class="space-y-4">
+              <div class="space-y-1">
+                <p class="console-label">Approval Required</p>
+                <p class="text-sm text-[var(--text-muted)]">
+                  These tool calls are blocked until an operator responds.
+                </p>
               </div>
 
-              <div class="mt-6 space-y-4">
+              <div class="space-y-3">
                 <div
-                  :for={event <- @display_events}
-                  id={"timeline-event-#{event.id}"}
-                  class="rounded-[1.5rem] border border-neutral-200 bg-neutral-50 p-5"
+                  :for={event <- @pending_confirmations}
+                  id={"pending-confirmation-#{event.id}"}
+                  class="rounded-[8px] border border-[var(--accent)]/20 bg-[var(--panel-bg)] p-4"
                 >
-                  <div class="flex flex-wrap items-start justify-between gap-4">
-                    <div class="space-y-3">
+                  <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                    <div class="min-w-0 space-y-2">
                       <div class="flex flex-wrap items-center gap-2">
-                        <span class="inline-flex items-center rounded-full bg-neutral-900 px-2.5 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-white">
-                          #{event.sequence}
+                        <span class={tool_status_badge_class(:awaiting_confirmation)}>
+                          {tool_status_label(:awaiting_confirmation)}
                         </span>
-                        <span class={event_badge_class(event.type)}>
-                          {event.type}
-                        </span>
-                        <span class="inline-flex items-center rounded-full bg-white px-2.5 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-neutral-500">
+                        <span class="console-badge console-badge-neutral px-2 py-1 text-[10px]">
                           {event_thread_label(event, @thread_labels)}
                         </span>
                       </div>
-                      <p class="text-sm leading-6 text-neutral-800">
+                      <p class="text-sm font-semibold text-[var(--text-strong)]">
                         {timeline_summary(event)}
                       </p>
+                      <pre :if={tool_request_detail(event)} class="console-code-block">
+                        {tool_request_detail(event)}
+                      </pre>
                     </div>
-                    <p class="text-xs uppercase tracking-[0.18em] text-neutral-400">
-                      {event_timestamp(event)}
-                    </p>
+
+                    <div class="flex flex-wrap gap-2">
+                      <button
+                        id={"confirm-allow-#{event.id}"}
+                        type="button"
+                        phx-click="confirm_tool"
+                        phx-value-tool_use_id={event.id}
+                        phx-value-result="allow"
+                        class="console-button console-button-primary"
+                      >
+                        Allow
+                      </button>
+                      <button
+                        id={"confirm-deny-#{event.id}"}
+                        type="button"
+                        phx-click="confirm_tool"
+                        phx-value-tool_use_id={event.id}
+                        phx-value-result="deny"
+                        class="console-button console-button-secondary"
+                      >
+                        Deny
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
-            </section>
+            </div>
+          </section>
 
+          <div class="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px]">
             <section
-              id="session-tool-executions"
-              class="rounded-[2rem] border border-neutral-200 bg-white p-6 shadow-sm"
+              id="session-trace"
+              class="console-panel console-scroll max-h-[calc(100vh-18rem)] overflow-y-auto"
             >
-              <div class="flex flex-wrap items-start justify-between gap-4">
-                <div>
-                  <p class="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-700">
-                    Tool Execution
-                  </p>
-                  <h2 class="mt-2 text-xl font-semibold tracking-tight text-neutral-950">
-                    Inputs and results
-                  </h2>
-                  <p class="mt-1 text-sm leading-6 text-neutral-600">
-                    Every tool invocation stays paired with its input, confirmation state, and final result payload when available.
-                  </p>
+              <div class="console-transcript">
+                <div :if={@display_events == []}>
+                  <.empty_state
+                    title="No transcript events"
+                    description="This trace scope does not have any visible events yet."
+                  />
                 </div>
-              </div>
 
-              <div
-                :if={@tool_entries == []}
-                class="mt-6 rounded-[1.5rem] border border-dashed border-neutral-300 bg-neutral-50 px-5 py-10 text-center text-sm text-neutral-500"
-              >
-                No tool executions were recorded for the current trace scope.
-              </div>
-
-              <div :if={@tool_entries != []} class="mt-6 space-y-5">
-                <div
-                  :for={entry <- @tool_entries}
-                  id={"tool-entry-#{entry.use_event.id}"}
-                  class="rounded-[1.5rem] border border-neutral-200 bg-neutral-50 p-5"
-                >
-                  <div class="flex flex-wrap items-start justify-between gap-4">
-                    <div class="space-y-2">
-                      <div class="flex flex-wrap items-center gap-2">
-                        <p class="text-base font-semibold text-neutral-950">{entry.tool_name}</p>
-                        <span class={tool_kind_badge_class(entry.kind)}>
-                          {tool_kind_label(entry.kind)}
-                        </span>
-                        <span class={tool_status_badge_class(entry.status)}>
-                          {tool_status_label(entry.status)}
-                        </span>
-                      </div>
-                      <p class="text-sm leading-6 text-neutral-600">
-                        {tool_entry_summary(entry)}
-                      </p>
-                    </div>
-                    <p class="text-xs uppercase tracking-[0.18em] text-neutral-400">
-                      Event #{entry.use_event.sequence}
-                    </p>
-                  </div>
-
-                  <div
-                    :if={entry.awaiting_confirmation?}
-                    id={"pending-confirmation-#{entry.use_event.id}"}
-                    class="mt-5 rounded-[1.25rem] border border-amber-200 bg-amber-50 p-4"
-                  >
-                    <div class="flex flex-wrap items-start justify-between gap-4">
-                      <div>
-                        <p class="text-sm font-semibold text-amber-950">
-                          Approval required
-                        </p>
-                        <p class="mt-1 text-sm leading-6 text-amber-900/80">
-                          This session is paused until a `user.tool_confirmation` event allows or denies the request.
-                        </p>
-                      </div>
-                      <div class="flex flex-wrap gap-3">
-                        <.button
-                          id={"confirm-allow-#{entry.use_event.id}"}
-                          phx-click="confirm_tool"
-                          phx-value-tool_use_id={entry.use_event.id}
-                          phx-value-result="allow"
-                          class="rounded-full bg-emerald-600 px-5 text-white hover:bg-emerald-500"
-                        >
-                          Allow
-                        </.button>
-                        <.button
-                          id={"confirm-deny-#{entry.use_event.id}"}
-                          phx-click="confirm_tool"
-                          phx-value-tool_use_id={entry.use_event.id}
-                          phx-value-result="deny"
-                          class="rounded-full border border-rose-300 bg-white px-5 text-rose-700 hover:border-rose-400 hover:bg-rose-50"
-                        >
-                          Deny
-                        </.button>
-                      </div>
-                    </div>
-                  </div>
-
-                  <div class="mt-5 grid gap-4 lg:grid-cols-2">
-                    <div class="rounded-[1.25rem] border border-neutral-200 bg-white p-4">
-                      <p class="text-xs font-semibold uppercase tracking-[0.2em] text-neutral-500">
-                        Input
-                      </p>
-                      <pre class="mt-3 overflow-x-auto text-xs leading-6 text-neutral-800">{entry.input_json}</pre>
-                    </div>
-                    <div class="rounded-[1.25rem] border border-neutral-200 bg-white p-4">
-                      <p class="text-xs font-semibold uppercase tracking-[0.2em] text-neutral-500">
-                        Outcome
-                      </p>
-                      <pre class="mt-3 overflow-x-auto text-xs leading-6 text-neutral-800">{entry.outcome_json}</pre>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </section>
-          </div>
-
-          <div class="space-y-8">
-            <section
-              id="session-metrics"
-              class="rounded-[2rem] border border-neutral-200 bg-white p-6 shadow-sm"
-            >
-              <div>
-                <p class="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-700">
-                  Provider Metrics
-                </p>
-                <h2 class="mt-2 text-xl font-semibold tracking-tight text-neutral-950">
-                  Usage snapshot
-                </h2>
-                <p class="mt-1 text-sm leading-6 text-neutral-600">
-                  Token or provider usage is aggregated from recorded event payloads when the runtime supplies it.
-                </p>
-              </div>
-
-              <%= if @metrics do %>
-                <div class="mt-6 grid gap-4 sm:grid-cols-2">
-                  <div
-                    :for={{metric, value} <- metric_entries(@metrics)}
-                    class="rounded-[1.25rem] border border-neutral-200 bg-neutral-50 p-4"
-                  >
-                    <p class="text-xs font-semibold uppercase tracking-[0.2em] text-neutral-500">
-                      {metric}
-                    </p>
-                    <p class="mt-3 text-2xl font-semibold tracking-tight text-neutral-950">
-                      {value}
-                    </p>
-                  </div>
-                </div>
-              <% else %>
-                <div class="mt-6 rounded-[1.5rem] border border-dashed border-neutral-300 bg-neutral-50 px-5 py-10 text-center text-sm text-neutral-500">
-                  No provider metrics were recorded for this trace yet.
-                </div>
-              <% end %>
-            </section>
-
-            <section
-              id="session-raw-events"
-              class="rounded-[2rem] border border-neutral-200 bg-white p-6 shadow-sm"
-            >
-              <div>
-                <p class="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-700">
-                  Raw Events
-                </p>
-                <h2 class="mt-2 text-xl font-semibold tracking-tight text-neutral-950">
-                  Persisted payloads
-                </h2>
-                <p class="mt-1 text-sm leading-6 text-neutral-600">
-                  Directly inspect the stored event shape, including payload, stop reason, and thread identifiers.
-                </p>
-              </div>
-
-              <div class="mt-6 space-y-4">
                 <div
                   :for={event <- @display_events}
-                  id={"raw-event-#{event.id}"}
-                  class="rounded-[1.5rem] border border-neutral-200 bg-neutral-50 p-4"
+                  class={[
+                    "console-transcript-item",
+                    @selected_event_id == event.id && "console-transcript-item-selected"
+                  ]}
                 >
-                  <div class="flex flex-wrap items-center justify-between gap-3">
-                    <p class="text-sm font-semibold text-neutral-950">
-                      #{event.sequence} · {event.type}
-                    </p>
-                    <p class="text-xs uppercase tracking-[0.18em] text-neutral-400">
-                      {event_timestamp(event)}
-                    </p>
+                  <div class={transcript_event_class(event)}>
+                    <div class="flex items-start justify-between gap-3">
+                      <div class="min-w-0 flex-1 space-y-2">
+                        <%= cond do %>
+                          <% event.type == "user.message" -> %>
+                            <div class="flex items-center gap-2">
+                              <.status_badge status="active" size="small" />
+                              <p class="text-sm font-semibold text-[var(--text-strong)]">You</p>
+                              <p class="console-list-meta">{event_timestamp(event)}</p>
+                            </div>
+                            <p class="console-value">{text_content(event.content)}</p>
+                          <% event.type == "agent.message" -> %>
+                            <div class="flex flex-wrap items-center gap-2">
+                              <.status_badge status="running" size="small" />
+                              <p class="text-sm font-semibold text-[var(--text-strong)]">
+                                {session_agent_name(@session)}
+                              </p>
+                              <span class="console-badge console-badge-neutral px-2 py-1 text-[10px]">
+                                {event_thread_label(event, @thread_labels)}
+                              </span>
+                              <p class="console-list-meta">{event_timestamp(event)}</p>
+                            </div>
+                            <p class="console-value">{text_content(event.content)}</p>
+                          <% event.type == "agent.thinking" -> %>
+                            <div class="flex items-center gap-2">
+                              <.status_badge status="running" size="small" />
+                              <p class="text-sm font-semibold text-[var(--text-strong)]">Thinking</p>
+                              <p class="console-list-meta">{event_timestamp(event)}</p>
+                            </div>
+                            <p class="console-copy italic">{timeline_summary(event)}</p>
+                          <% tool_use_event?(event) or tool_result_event?(event) -> %>
+                            <div class="flex flex-wrap items-center gap-2">
+                              <p class="text-sm font-semibold text-[var(--text-strong)]">
+                                {payload_value(event.payload, "tool_name") || "Tool"}
+                              </p>
+                              <span class={tool_kind_badge_class(tool_kind(event.type))}>
+                                {tool_kind_label(tool_kind(event.type))}
+                              </span>
+                              <span
+                                :if={awaiting_confirmation_event?(event)}
+                                class={tool_status_badge_class(:awaiting_confirmation)}
+                              >
+                                {tool_status_label(:awaiting_confirmation)}
+                              </span>
+                              <p class="console-list-meta">{event_timestamp(event)}</p>
+                            </div>
+                            <p class="console-copy">{timeline_summary(event)}</p>
+                            <div
+                              :if={awaiting_confirmation_event?(event)}
+                              class="flex flex-wrap gap-2 pt-2"
+                            >
+                              <button
+                                type="button"
+                                phx-click="confirm_tool"
+                                phx-value-tool_use_id={event.id}
+                                phx-value-result="allow"
+                                class="console-button console-button-primary"
+                              >
+                                Allow
+                              </button>
+                              <button
+                                type="button"
+                                phx-click="confirm_tool"
+                                phx-value-tool_use_id={event.id}
+                                phx-value-result="deny"
+                                class="console-button console-button-secondary"
+                              >
+                                Deny
+                              </button>
+                            </div>
+                          <% true -> %>
+                            <div class="flex flex-wrap items-center gap-2">
+                              <span class={event_badge_class(event.type)}>{event.type}</span>
+                              <p class="console-list-meta">{event_timestamp(event)}</p>
+                            </div>
+                            <p class="console-copy">{timeline_summary(event)}</p>
+                        <% end %>
+                      </div>
+
+                      <button
+                        type="button"
+                        phx-click="select_event"
+                        phx-value-id={event.id}
+                        class="console-button console-button-ghost console-xl-up-inline-flex"
+                      >
+                        Inspect
+                      </button>
+                    </div>
                   </div>
-                  <pre class="mt-4 overflow-x-auto text-xs leading-6 text-neutral-800">{pretty_event(event)}</pre>
                 </div>
               </div>
             </section>
+
+            <aside class="hidden xl:block">
+              <section class="console-panel sticky top-24 space-y-4">
+                <div class="space-y-1">
+                  <p class="console-label">Detail</p>
+                  <h2 class="text-lg font-semibold text-[var(--text-strong)]">
+                    {if @selected_event,
+                      do: "Event ##{@selected_event.sequence}",
+                      else: "Session context"}
+                  </h2>
+                </div>
+
+                <%= if @selected_event do %>
+                  <div class="space-y-4">
+                    <div class="flex flex-wrap items-center gap-2">
+                      <span class={event_badge_class(@selected_event.type)}>
+                        {@selected_event.type}
+                      </span>
+                      <span class="console-badge console-badge-neutral px-2 py-1 text-[10px]">
+                        {event_thread_label(@selected_event, @thread_labels)}
+                      </span>
+                    </div>
+                    <p class="console-copy">{timeline_summary(@selected_event)}</p>
+                    <div>
+                      <p class="console-label">Payload</p>
+                      <.json_block
+                        data={SessionEventDefinition.serialize_event(@selected_event)}
+                        class="max-h-[24rem] overflow-y-auto"
+                      />
+                    </div>
+                  </div>
+                <% else %>
+                  <div class="space-y-3">
+                    <p class="console-copy">
+                      Pick any transcript item to inspect its raw payload, thread label, and tool details without leaving the conversation flow.
+                    </p>
+                    <p class="console-list-meta">
+                      Current scope: {@selected_trace_label}
+                    </p>
+                  </div>
+                <% end %>
+              </section>
+            </aside>
           </div>
+
+          <section :if={@can_compose} class="console-composer">
+            <.form
+              for={@composer_form}
+              id="session-composer"
+              phx-change="validate_composer"
+              phx-submit="send_message"
+            >
+              <div class="flex flex-col gap-3 sm:flex-row sm:items-end">
+                <div class="min-w-0 flex-1">
+                  <textarea
+                    name="composer[prompt]"
+                    rows="2"
+                    placeholder="Send a follow-up to this session"
+                  >{@composer_params["prompt"]}</textarea>
+                </div>
+                <button type="submit" class="console-button console-button-primary">
+                  <.icon name="hero-paper-airplane" class="size-4" /> Send
+                </button>
+              </div>
+            </.form>
+          </section>
+        </div>
+
+        <div :if={@view_tab == "debug"} class="space-y-6">
+          <section class="space-y-3">
+            <div class="space-y-1">
+              <p class="console-label">Thread traces</p>
+              <p class="console-copy">
+                Match the debug timeline to the same thread scope used in the transcript.
+              </p>
+            </div>
+
+            <div class="flex flex-wrap gap-2">
+              <.link
+                id="debug-trace-scope-all"
+                patch={trace_scope_path(@session, nil)}
+                class={[
+                  "console-button",
+                  if(is_nil(@selected_thread),
+                    do: "console-button-primary",
+                    else: "console-button-secondary"
+                  )
+                ]}
+              >
+                All traces
+              </.link>
+              <.link
+                :for={thread <- @threads}
+                id={"debug-trace-scope-thread-#{thread.id}"}
+                patch={trace_scope_path(@session, thread)}
+                class={[
+                  "console-button",
+                  if(selected_thread?(@selected_thread, thread),
+                    do: "console-button-primary",
+                    else: "console-button-secondary"
+                  )
+                ]}
+              >
+                {thread_scope_label(thread)}
+              </.link>
+            </div>
+          </section>
+
+          <div class="console-tabs">
+            <button
+              :for={tab <- debug_tabs()}
+              type="button"
+              phx-click="set_debug_tab"
+              phx-value-tab={tab.value}
+              class={["console-tab", @debug_tab == tab.value && "console-tab-active"]}
+            >
+              {tab.label}
+            </button>
+          </div>
+
+          <section
+            :if={@debug_tab == "timeline"}
+            id="session-timeline"
+            class="console-panel space-y-3"
+          >
+            <div
+              :if={@latest_error_event}
+              class="rounded-[8px] border border-[var(--danger)]/20 bg-[var(--danger-soft)] p-4"
+            >
+              <p class="text-sm font-semibold text-[var(--danger)]">Latest error</p>
+              <p class="console-copy mt-2">{timeline_summary(@latest_error_event)}</p>
+            </div>
+
+            <div
+              :for={event <- @display_events}
+              class="rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-muted)] p-4"
+            >
+              <div class="flex flex-wrap items-start justify-between gap-3">
+                <div class="space-y-2">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <span class="console-badge console-badge-neutral px-2 py-1 text-[10px]">
+                      #{event.sequence}
+                    </span>
+                    <span class={event_badge_class(event.type)}>{event.type}</span>
+                    <span class="console-badge console-badge-neutral px-2 py-1 text-[10px]">
+                      {event_thread_label(event, @thread_labels)}
+                    </span>
+                  </div>
+                  <p class="console-copy">{timeline_summary(event)}</p>
+                </div>
+                <p class="console-list-meta">{event_timestamp(event)}</p>
+              </div>
+            </div>
+          </section>
+
+          <section
+            :if={@debug_tab == "tools"}
+            id="session-tool-executions"
+            class="console-panel space-y-4"
+          >
+            <div :if={@tool_entries == []}>
+              <.empty_state
+                title="No tool executions"
+                description="This trace scope has not recorded any tool use or tool result events."
+              />
+            </div>
+
+            <div :if={@tool_entries != []} class="space-y-4">
+              <div
+                :for={entry <- @tool_entries}
+                class="rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-muted)] p-4"
+              >
+                <div class="space-y-3">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <p class="text-sm font-semibold text-[var(--text-strong)]">{entry.tool_name}</p>
+                    <span class={tool_kind_badge_class(entry.kind)}>
+                      {tool_kind_label(entry.kind)}
+                    </span>
+                    <span class={tool_status_badge_class(entry.status)}>
+                      {tool_status_label(entry.status)}
+                    </span>
+                  </div>
+                  <p class="console-copy">{tool_entry_summary(entry)}</p>
+                  <div :if={entry.awaiting_confirmation?} class="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      phx-click="confirm_tool"
+                      phx-value-tool_use_id={entry.use_event.id}
+                      phx-value-result="allow"
+                      class="console-button console-button-primary"
+                    >
+                      Allow
+                    </button>
+                    <button
+                      type="button"
+                      phx-click="confirm_tool"
+                      phx-value-tool_use_id={entry.use_event.id}
+                      phx-value-result="deny"
+                      class="console-button console-button-secondary"
+                    >
+                      Deny
+                    </button>
+                  </div>
+                  <div class="grid gap-4 lg:grid-cols-2">
+                    <div>
+                      <p class="console-label">Input</p>
+                      <pre class="console-code-block">{entry.input_json}</pre>
+                    </div>
+                    <div>
+                      <p class="console-label">Outcome</p>
+                      <pre class="console-code-block">{entry.outcome_json}</pre>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section :if={@debug_tab == "metrics"} id="session-metrics" class="console-panel space-y-4">
+            <%= if @metrics do %>
+              <div class="console-grid-3">
+                <.kpi_card
+                  :for={{label, value} <- metric_entries(@metrics)}
+                  label={label}
+                  value={value}
+                />
+              </div>
+            <% else %>
+              <.empty_state
+                title="No provider metrics"
+                description="Usage data has not been recorded for this trace yet."
+              />
+            <% end %>
+          </section>
+
+          <section :if={@debug_tab == "raw"} id="session-raw-events" class="console-panel space-y-3">
+            <div
+              :for={event <- @display_events}
+              class="rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-muted)] p-4"
+            >
+              <div class="flex flex-wrap items-center justify-between gap-3">
+                <p class="text-sm font-semibold text-[var(--text-strong)]">
+                  #{event.sequence} · {event.type}
+                </p>
+                <p class="console-list-meta">{event_timestamp(event)}</p>
+              </div>
+              <pre class="console-code-block mt-4">{pretty_event(event)}</pre>
+            </div>
+          </section>
         </div>
       <% end %>
     </Layouts.app>
     """
+  end
+
+  defp default_session_filters do
+    %{"search" => "", "status" => "all"}
+  end
+
+  defp normalize_session_filters(params) do
+    %{
+      "search" => Map.get(params, "search", ""),
+      "status" => Map.get(params, "status", "all")
+    }
+  end
+
+  defp filter_sessions(sessions, filters) do
+    search = filters["search"] |> String.downcase() |> String.trim()
+    status = filters["status"]
+
+    Enum.filter(sessions, fn session ->
+      session_status_match?(session, status) and session_search_match?(session, search)
+    end)
+  end
+
+  defp session_status_filters do
+    [
+      %{label: "All", value: "all"},
+      %{label: "Needs Input", value: "needs_input"},
+      %{label: "Running", value: "running"},
+      %{label: "Finished", value: "finished"},
+      %{label: "Errored", value: "errored"}
+    ]
+  end
+
+  defp session_status_match?(session, "needs_input"),
+    do: requires_action?(session.stop_reason)
+
+  defp session_status_match?(session, "running"), do: to_string(session.status) == "running"
+
+  defp session_status_match?(session, "finished"),
+    do: to_string(session.status) in ["idle", "archived"]
+
+  defp session_status_match?(session, "errored"), do: to_string(session.status) == "errored"
+  defp session_status_match?(_session, _status), do: true
+
+  defp session_search_match?(_session, ""), do: true
+
+  defp session_search_match?(session, search) do
+    haystack =
+      [session.title, session_agent_name(session), session_model(session)]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.join(" ")
+      |> String.downcase()
+
+    String.contains?(haystack, search)
+  end
+
+  defp default_composer_params, do: %{"prompt" => ""}
+
+  defp normalize_composer_params(params) do
+    %{"prompt" => Map.get(params, "prompt", "")}
+  end
+
+  defp normalized_user_message(message, %Session{} = session, actor) do
+    params = %{
+      "type" => "user.message",
+      "content" => [%{"type" => "text", "text" => message}]
+    }
+
+    SessionEventDefinition.normalize_append_payload(params, session, actor)
+  end
+
+  defp selected_event(events, nil), do: List.last(events)
+
+  defp selected_event(events, selected_event_id) do
+    Enum.find(events, List.last(events), &(&1.id == selected_event_id))
+  end
+
+  defp session_status_badge(%Session{} = session) do
+    if requires_action?(session.stop_reason), do: "needs_input", else: session.status
+  end
+
+  defp session_composable?(nil), do: false
+
+  defp session_composable?(%Session{} = session) do
+    to_string(session.status) in ["idle", "running"] or requires_action?(session.stop_reason)
+  end
+
+  defp metric_value(nil, _key), do: "0"
+  defp metric_value(metrics, key), do: format_metric(metrics[key] || metrics[to_string(key)])
+
+  defp transcript_event_class(%SessionEvent{type: "agent.message"}) do
+    "rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-muted)] p-4"
+  end
+
+  defp transcript_event_class(%SessionEvent{type: "user.message"}) do
+    "rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-bg)] p-4"
+  end
+
+  defp transcript_event_class(%SessionEvent{type: type}) when type in @tool_use_event_types do
+    "rounded-[8px] border border-[var(--accent)]/20 bg-[var(--accent-soft)] p-4"
+  end
+
+  defp transcript_event_class(%SessionEvent{type: type}) when type in @tool_result_event_types do
+    "rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-muted)] p-4"
+  end
+
+  defp transcript_event_class(%SessionEvent{}) do
+    "rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-bg)] p-4"
+  end
+
+  defp tool_use_event?(%SessionEvent{type: type}), do: type in @tool_use_event_types
+  defp tool_use_event?(_event), do: false
+
+  defp tool_result_event?(%SessionEvent{type: type}), do: type in @tool_result_event_types
+  defp tool_result_event?(_event), do: false
+
+  defp debug_tabs do
+    [
+      %{label: "Timeline", value: "timeline"},
+      %{label: "Tools", value: "tools"},
+      %{label: "Metrics", value: "metrics"},
+      %{label: "Raw Events", value: "raw"}
+    ]
+  end
+
+  defp pending_session_count(actor) do
+    actor
+    |> list_sessions()
+    |> count_requires_action()
   end
 
   defp load_detail(session_id, selected_thread_id, actor) do
@@ -1007,6 +1441,17 @@ defmodule JidoManagedAgentsWeb.SessionObservabilityLive do
     end
   end
 
+  defp tool_request_detail(%SessionEvent{} = event) do
+    input = payload_value(event.payload, "input")
+
+    cond do
+      is_binary(payload_value(input, "command")) -> payload_value(input, "command")
+      is_binary(payload_value(input, "prompt")) -> payload_value(input, "prompt")
+      is_map(input) and map_size(input) > 0 -> pretty_data(input)
+      true -> nil
+    end
+  end
+
   defp text_or_fallback(content, fallback) do
     case text_content(content) do
       "" -> fallback
@@ -1122,10 +1567,6 @@ defmodule JidoManagedAgentsWeb.SessionObservabilityLive do
   defp short_id(nil), do: "unknown"
   defp short_id(id) when is_binary(id), do: String.slice(id, 0, 8)
 
-  defp status_label(status) when is_atom(status), do: status |> to_string() |> String.capitalize()
-  defp status_label(status) when is_binary(status), do: String.capitalize(status)
-  defp status_label(_status), do: "Unknown"
-
   defp confirmation_message("allow"), do: "Approval submitted. The session resumed."
 
   defp confirmation_message("deny"),
@@ -1161,29 +1602,6 @@ defmodule JidoManagedAgentsWeb.SessionObservabilityLive do
 
   defp event_badge_class(_type) do
     "inline-flex items-center rounded-full bg-cyan-100 px-2.5 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-cyan-900"
-  end
-
-  defp status_badge_class(:running),
-    do:
-      "inline-flex items-center rounded-full bg-cyan-100 px-2.5 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-cyan-900"
-
-  defp status_badge_class(:archived),
-    do:
-      "inline-flex items-center rounded-full bg-neutral-900 px-2.5 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-white"
-
-  defp status_badge_class(_status),
-    do:
-      "inline-flex items-center rounded-full bg-emerald-100 px-2.5 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-emerald-900"
-
-  defp detail_status_badge_class(status) do
-    base =
-      "inline-flex items-center rounded-full px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.2em] "
-
-    case status do
-      :running -> base <> "bg-cyan-300/90 text-cyan-950"
-      :archived -> base <> "bg-white/15 text-white"
-      _other -> base <> "bg-emerald-300/90 text-emerald-950"
-    end
   end
 
   defp tool_kind_label(:builtin), do: "Built-in"
@@ -1243,51 +1661,4 @@ defmodule JidoManagedAgentsWeb.SessionObservabilityLive do
     do: "Custom tool execution tracked in the session event log."
 
   defp tool_entry_summary(_entry), do: "Built-in tool execution captured from the runtime."
-
-  defp metric_card(assigns) do
-    ~H"""
-    <div>
-      <p class="text-xs uppercase tracking-[0.2em] text-current/65">{@label}</p>
-      <p class="mt-2 text-2xl font-semibold tracking-tight">{@value}</p>
-    </div>
-    """
-  end
-
-  defp console_tab(%{navigate: nil} = assigns) do
-    ~H"""
-    <span class="inline-flex items-center rounded-full border border-white/15 bg-white/10 px-4 py-2 text-sm font-medium text-white">
-      {@label}
-    </span>
-    """
-  end
-
-  defp console_tab(assigns) do
-    ~H"""
-    <.link
-      navigate={@navigate}
-      class="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white/80 transition hover:bg-white/10 hover:text-white"
-    >
-      {@label}
-    </.link>
-    """
-  end
-
-  defp trace_scope_button(assigns) do
-    ~H"""
-    <.link
-      id={@id}
-      patch={@patch}
-      class={[
-        "inline-flex items-center rounded-full px-4 py-2 text-sm font-medium transition",
-        if(@active,
-          do: "border border-cyan-300 bg-cyan-50 text-cyan-900",
-          else:
-            "border border-neutral-200 bg-neutral-50 text-neutral-600 hover:border-cyan-300 hover:bg-cyan-50 hover:text-cyan-900"
-        )
-      ]}
-    >
-      {@label}
-    </.link>
-    """
-  end
 end

--- a/lib/jido_managed_agents_web/live/vault_console_live.ex
+++ b/lib/jido_managed_agents_web/live/vault_console_live.ex
@@ -26,6 +26,8 @@ defmodule JidoManagedAgentsWeb.VaultConsoleLive do
       |> assign(:selected_vault, nil)
       |> assign(:credentials, [])
       |> assign(:selected_credential, nil)
+      |> assign(:show_create_vault, false)
+      |> assign(:show_credential_form, false)
       |> assign(:vault_errors, [])
       |> assign(:credential_errors, [])
       |> assign_vault_form(default_vault_params())
@@ -47,6 +49,7 @@ defmodule JidoManagedAgentsWeb.VaultConsoleLive do
        |> assign(:selected_vault, vault)
        |> assign(:credentials, list_credentials(vault, actor))
        |> assign(:selected_credential, credential)
+       |> assign(:show_credential_form, true)
        |> assign(:page_title, "#{vault_display_name(vault)} · Vaults")
        |> assign_credential_form(credential_form_params(credential))}
     else
@@ -73,6 +76,7 @@ defmodule JidoManagedAgentsWeb.VaultConsoleLive do
          |> assign(:selected_vault, vault)
          |> assign(:credentials, list_credentials(vault, actor))
          |> assign(:selected_credential, nil)
+         |> assign(:show_credential_form, false)
          |> assign(:page_title, "#{vault_display_name(vault)} · Vaults")
          |> assign_credential_form(default_credential_params())}
 
@@ -97,6 +101,7 @@ defmodule JidoManagedAgentsWeb.VaultConsoleLive do
      |> assign(:selected_vault, nil)
      |> assign(:credentials, [])
      |> assign(:selected_credential, nil)
+     |> assign(:show_credential_form, false)
      |> assign(:page_title, "Vaults")
      |> assign_credential_form(default_credential_params())}
   end
@@ -104,6 +109,10 @@ defmodule JidoManagedAgentsWeb.VaultConsoleLive do
   @impl true
   def handle_event("validate_vault", %{"vault" => params}, socket) do
     {:noreply, assign_vault_form(socket, params)}
+  end
+
+  def handle_event("toggle_create_vault", _params, socket) do
+    {:noreply, update(socket, :show_create_vault, &(!&1))}
   end
 
   def handle_event("create_vault", %{"vault" => params}, socket) do
@@ -126,6 +135,18 @@ defmodule JidoManagedAgentsWeb.VaultConsoleLive do
 
   def handle_event("validate_credential", %{"credential" => params}, socket) do
     {:noreply, assign_credential_form(socket, params)}
+  end
+
+  def handle_event("show_new_credential", _params, %{assigns: %{selected_vault: nil}} = socket) do
+    {:noreply, socket}
+  end
+
+  def handle_event("show_new_credential", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:selected_credential, nil)
+     |> assign(:show_credential_form, true)
+     |> assign_credential_form(default_credential_params())}
   end
 
   def handle_event(
@@ -173,514 +194,328 @@ defmodule JidoManagedAgentsWeb.VaultConsoleLive do
       flash={@flash}
       current_scope={@current_scope}
       current_user={@current_user}
-      main_class="px-4 py-8 sm:px-6 lg:px-8"
-      container_class="mx-auto max-w-7xl space-y-8"
+      section={:vaults}
+      main_class="px-4 py-6 sm:px-6 lg:px-8"
+      container_class="mx-auto max-w-7xl space-y-6"
     >
-      <section class="overflow-hidden rounded-[2rem] border border-sky-200/70 bg-[radial-gradient(circle_at_top_left,_rgba(59,130,246,0.18),_transparent_40%),linear-gradient(135deg,_#0f172a,_#14213d_58%,_#1d4ed8)] text-white shadow-2xl shadow-sky-950/20">
-        <div class="grid gap-8 px-6 py-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)] lg:px-10">
-          <div class="space-y-4">
-            <p class="text-xs font-semibold uppercase tracking-[0.28em] text-sky-200">
-              Secrets And Identity
-            </p>
-            <h1 class="max-w-3xl text-3xl font-semibold tracking-tight sm:text-4xl">
-              Vaults & credentials
-            </h1>
-            <p class="max-w-2xl text-sm leading-6 text-sky-50/80">
-              Register per-user credentials once, match them by MCP server URL, and rotate write-only secrets without falling back to the raw API.
-            </p>
-            <div class="flex flex-wrap gap-3 pt-2">
-              <.console_tab navigate={~p"/console/agents/new"} label="Agents" />
-              <.console_tab navigate={~p"/console/environments"} label="Environments" />
-              <.console_tab active label="Vaults" />
-            </div>
-          </div>
-          <div class="grid gap-4 rounded-[1.5rem] border border-white/10 bg-white/5 p-5 text-sm text-sky-50/90 sm:grid-cols-3 lg:grid-cols-1 xl:grid-cols-3">
-            <.metric_card label="Vaults" value={length(@vaults)} />
-            <.metric_card label="Credentials" value={@total_credential_count} />
-            <.metric_card label="Selected" value={length(@credentials)} />
-          </div>
-        </div>
-      </section>
+      <.page_header
+        title="Vaults & Credentials"
+        description="Manage write-only credential vaults scoped to MCP server URLs."
+      />
 
-      <div class="grid gap-8 xl:grid-cols-[minmax(0,0.88fr)_minmax(0,1.12fr)]">
-        <div class="space-y-8">
-          <section class="rounded-[2rem] border border-neutral-200 bg-white p-6 shadow-sm">
-            <div>
-              <p class="text-xs font-semibold uppercase tracking-[0.24em] text-sky-700">
-                Create vault
-              </p>
-              <h2 class="mt-2 text-xl font-semibold tracking-tight text-neutral-950">
-                New vault
-              </h2>
-              <p class="mt-1 text-sm leading-6 text-neutral-600">
-                Vaults group credentials for one dashboard user. Sessions reference the vault ID, then resolve the matching credential by MCP server URL at runtime.
-              </p>
-            </div>
-
-            <div
-              :if={@vault_errors != []}
-              id="vault-error-list"
-              class="mt-6 rounded-[1.5rem] border border-rose-200 bg-rose-50 px-5 py-4 text-sm text-rose-900"
+      <div class="grid gap-6 lg:grid-cols-5">
+        <section class="space-y-3 lg:col-span-2">
+          <div class="rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-bg)]">
+            <button
+              type="button"
+              phx-click="toggle_create_vault"
+              class="flex w-full items-center justify-between p-4 text-sm font-medium text-[var(--text-strong)]"
             >
-              <p class="font-semibold">Vault could not be created.</p>
-              <p :for={error <- @vault_errors} class="mt-2">{error}</p>
-            </div>
+              <span class="flex items-center gap-2">
+                <.icon name="hero-plus" class="size-3.5" /> New Vault
+              </span>
+              <.icon
+                name={if(@show_create_vault, do: "hero-chevron-down", else: "hero-chevron-right")}
+                class="size-4 text-[var(--text-muted)]"
+              />
+            </button>
 
-            <.form
-              for={@vault_form}
-              id="vault-form"
-              class="mt-6 space-y-5"
-              phx-change="validate_vault"
-              phx-submit="create_vault"
-            >
-              <.input
-                field={@vault_form[:name]}
-                label="Vault name"
-                placeholder="Alice"
-              />
-              <.input
-                field={@vault_form[:description]}
-                type="textarea"
-                label="Description"
-                rows="4"
-                placeholder="Third-party service credentials for this user."
-              />
-              <div class="rounded-[1.5rem] border border-neutral-200 bg-neutral-50 p-4">
+            <div :if={@show_create_vault} class="border-t border-[var(--border-subtle)] p-4">
+              <div
+                :if={@vault_errors != []}
+                id="vault-error-list"
+                class="mb-3 rounded-[8px] border border-[var(--danger)]/20 bg-[var(--danger-soft)] px-4 py-3 text-sm text-[var(--text-strong)]"
+              >
+                <p :for={error <- @vault_errors}>{error}</p>
+              </div>
+
+              <.form
+                for={@vault_form}
+                id="vault-form"
+                class="space-y-3"
+                phx-change="validate_vault"
+                phx-submit="create_vault"
+              >
+                <.input field={@vault_form[:name]} label="Name" placeholder="My Vault" />
+                <.input
+                  field={@vault_form[:description]}
+                  label="Description"
+                  placeholder="What is this vault for?"
+                />
                 <.input
                   field={@vault_form[:metadata_json]}
                   type="textarea"
                   label="Metadata JSON"
-                  rows="7"
-                  placeholder={"{\n  \"external_user_id\": \"usr_abc123\"\n}"}
+                  rows="2"
                 />
-                <p class="mt-2 text-sm leading-6 text-neutral-500">
-                  Optional external identifiers or labels. The editor expects a JSON object.
-                </p>
-              </div>
-              <.button
-                id="vault-save-button"
-                class="rounded-full bg-sky-600 px-5 text-white hover:bg-sky-500"
-              >
-                Create vault
-              </.button>
-            </.form>
-          </section>
-
-          <section class="rounded-[2rem] border border-neutral-200 bg-white p-6 shadow-sm">
-            <div class="flex items-start justify-between gap-4">
-              <div>
-                <p class="text-xs font-semibold uppercase tracking-[0.24em] text-sky-700">
-                  Catalog
-                </p>
-                <h2 class="mt-2 text-xl font-semibold tracking-tight text-neutral-950">
-                  Vault list
-                </h2>
-                <p class="mt-1 text-sm leading-6 text-neutral-600">
-                  Choose a vault to add new credentials or rotate existing ones.
-                </p>
-              </div>
+                <.button id="vault-save-button" class="console-button console-button-primary">
+                  Create Vault
+                </.button>
+              </.form>
             </div>
-
-            <div id="vault-list" class="mt-6 space-y-3">
-              <div
-                :if={@vaults == []}
-                class="rounded-[1.5rem] border border-dashed border-neutral-300 bg-neutral-50 px-5 py-10 text-center text-sm text-neutral-500"
-              >
-                No vaults yet. Create one above to start attaching credentials.
-              </div>
-
-              <div :for={vault <- @vaults} class={vault_card_class(vault, @selected_vault)}>
-                <div class="flex items-start justify-between gap-4">
-                  <div class="space-y-2">
-                    <div class="flex flex-wrap items-center gap-2">
-                      <p class="text-base font-semibold text-neutral-950">
-                        {vault_display_name(vault)}
-                      </p>
-                      <span class="inline-flex items-center rounded-full bg-sky-100 px-2.5 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-sky-900">
-                        vault
-                      </span>
-                    </div>
-                    <p class="text-sm leading-6 text-neutral-600">
-                      {vault.description || "No description yet."}
-                    </p>
-                    <p class="text-xs uppercase tracking-[0.18em] text-neutral-400">
-                      Updated {ConsoleHelpers.format_timestamp(vault.updated_at)}
-                    </p>
-                  </div>
-                  <.button
-                    patch={~p"/console/vaults/#{vault.id}"}
-                    class="rounded-full border border-neutral-300 bg-white px-4 text-neutral-800 hover:border-sky-300 hover:bg-sky-50"
-                  >
-                    Open
-                  </.button>
-                </div>
-              </div>
-            </div>
-          </section>
-        </div>
-
-        <section class="rounded-[2rem] border border-neutral-200 bg-white p-6 shadow-sm">
-          <div
-            :if={is_nil(@selected_vault)}
-            class="flex h-full min-h-[34rem] flex-col items-center justify-center rounded-[1.5rem] border border-dashed border-neutral-300 bg-neutral-50 px-8 text-center"
-          >
-            <div class="flex size-14 items-center justify-center rounded-full bg-sky-100 text-sky-700">
-              <.icon name="hero-key" class="size-7" />
-            </div>
-            <h2 class="mt-5 text-2xl font-semibold tracking-tight text-neutral-950">
-              Select a vault
-            </h2>
-            <p class="mt-3 max-w-lg text-sm leading-7 text-neutral-600">
-              Credential forms stay scoped to one vault so rotation is obvious and the MCP server matching rules stay visible.
-            </p>
           </div>
 
-          <div :if={@selected_vault} class="space-y-8">
-            <div class="flex flex-wrap items-start justify-between gap-4">
-              <div>
-                <p class="text-xs font-semibold uppercase tracking-[0.24em] text-sky-700">
-                  Selected vault
-                </p>
-                <h2 class="mt-2 text-2xl font-semibold tracking-tight text-neutral-950">
-                  {vault_display_name(@selected_vault)}
-                </h2>
-                <p class="mt-2 max-w-2xl text-sm leading-6 text-neutral-600">
-                  {@selected_vault.description ||
-                    "Credentials in this vault are matched by MCP server URL at session runtime."}
-                </p>
-              </div>
-              <div class="rounded-[1.25rem] border border-neutral-200 bg-neutral-50 px-4 py-3 text-sm text-neutral-600">
-                <p class="font-medium text-neutral-900">Vault ID</p>
-                <p class="mt-1 font-mono text-xs">{@selected_vault.id}</p>
-              </div>
+          <div id="vault-list" class="space-y-2">
+            <div :if={@vaults == []}>
+              <.empty_state
+                title="No vaults"
+                description="Create one to start attaching credentials."
+              />
             </div>
 
-            <div class="rounded-[1.5rem] border border-amber-200 bg-amber-50 px-5 py-4 text-sm leading-6 text-amber-950">
+            <.link
+              :for={vault <- @vaults}
+              patch={~p"/console/vaults/#{vault.id}"}
+              class={[
+                "block rounded-[8px] border p-4 transition min-h-[56px]",
+                selected_vault?(@selected_vault, vault) &&
+                  "border-[var(--session)]/40 bg-[var(--session-soft)]",
+                !selected_vault?(@selected_vault, vault) &&
+                  "border-[var(--border-subtle)] bg-[var(--panel-bg)] hover:bg-[var(--panel-muted)]"
+              ]}
+            >
               <div class="flex items-start gap-3">
-                <.icon name="hero-lock-closed" class="mt-0.5 size-5 shrink-0" />
-                <div>
-                  <p class="font-semibold">Write-only secret fields</p>
-                  <p class="mt-1">
-                    Access tokens, refresh tokens, and client secrets are accepted on save and never rendered back. Leave a secret input blank during rotation to preserve the current stored value.
+                <span class="mt-0.5 inline-flex shrink-0 text-[var(--success)]">
+                  <.icon name="hero-lock-closed" class="size-4" />
+                </span>
+                <div class="min-w-0 flex-1">
+                  <div class="flex items-center gap-2">
+                    <p class="text-sm font-medium text-[var(--text-strong)]">
+                      {vault_display_name(vault)}
+                    </p>
+                    <span class="ml-auto text-[10px] text-[var(--text-muted)]">
+                      {credential_count(vault, @selected_vault, @credentials)}
+                      {if credential_count(vault, @selected_vault, @credentials) == 1,
+                        do: " cred",
+                        else: " creds"}
+                    </span>
+                  </div>
+                  <p :if={vault.description} class="mt-1 truncate text-xs text-[var(--text-muted)]">
+                    {vault.description}
                   </p>
                 </div>
               </div>
-            </div>
+            </.link>
+          </div>
+        </section>
 
-            <div class="grid gap-6 lg:grid-cols-[minmax(0,0.78fr)_minmax(0,1.22fr)]">
-              <div class="rounded-[1.5rem] border border-neutral-200 bg-neutral-50 p-4">
-                <div class="flex items-start justify-between gap-3">
-                  <div>
-                    <p class="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">
-                      Credentials
-                    </p>
-                    <h3 class="mt-2 text-lg font-semibold tracking-tight text-neutral-950">
-                      Stored routes
-                    </h3>
-                  </div>
-                  <.button
-                    :if={@selected_credential}
-                    patch={~p"/console/vaults/#{@selected_vault.id}"}
-                    class="rounded-full border border-neutral-300 bg-white px-4 text-neutral-800 hover:border-neutral-400 hover:bg-neutral-100"
+        <section class="lg:col-span-3">
+          <%= if @selected_vault do %>
+            <div class="space-y-4">
+              <div class="rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-bg)] p-4">
+                <div class="mb-2 flex items-center gap-2">
+                  <.icon name="hero-lock-closed" class="size-5 text-[var(--success)]" />
+                  <h2 class="text-base font-semibold text-[var(--text-strong)]">
+                    {vault_display_name(@selected_vault)}
+                  </h2>
+                </div>
+                <p :if={@selected_vault.description} class="mb-2 text-xs text-[var(--text-muted)]">
+                  {@selected_vault.description}
+                </p>
+                <p class="text-[10px] font-mono text-[var(--text-muted)]">ID: {@selected_vault.id}</p>
+                <div class="mt-3 rounded-[8px] border border-[var(--success)]/20 bg-[var(--success-soft)] p-3 text-xs text-[var(--success)]">
+                  Secrets are write-only. Stored values cannot be retrieved.
+                </div>
+              </div>
+
+              <div class="rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-bg)] p-4">
+                <div class="mb-3 flex items-center justify-between gap-3">
+                  <h3 class="text-sm font-semibold text-[var(--text-strong)]">Credentials</h3>
+                  <button
+                    id="show-credential-form-button"
+                    type="button"
+                    phx-click="show_new_credential"
+                    class="console-button console-button-secondary text-xs"
                   >
-                    New credential
-                  </.button>
+                    <.icon name="hero-plus" class="size-3" /> Add Credential
+                  </button>
                 </div>
 
-                <div id="credential-list" class="mt-5 space-y-3">
-                  <div
-                    :if={@credentials == []}
-                    class="rounded-[1.25rem] border border-dashed border-neutral-300 bg-white px-4 py-8 text-center text-sm text-neutral-500"
-                  >
-                    No credentials yet for this vault.
-                  </div>
-
-                  <div
-                    :for={credential <- @credentials}
-                    class={credential_card_class(credential, @selected_credential)}
-                  >
-                    <div class="flex items-start justify-between gap-4">
-                      <div class="space-y-2">
-                        <div class="flex flex-wrap items-center gap-2">
-                          <p class="text-sm font-semibold text-neutral-950">
+                <%= if @credentials == [] and !@show_credential_form and is_nil(@selected_credential) do %>
+                  <.empty_state
+                    title="No credentials"
+                    description="Add a credential to map secrets to an MCP server URL."
+                  />
+                <% else %>
+                  <div id="credential-list" class="space-y-2">
+                    <.link
+                      :for={credential <- @credentials}
+                      patch={
+                        ~p"/console/vaults/#{@selected_vault.id}/credentials/#{credential.id}/rotate"
+                      }
+                      class="flex min-h-[56px] items-center justify-between rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-muted)] p-4 transition hover:bg-[var(--panel-bg)]"
+                    >
+                      <div class="min-w-0 flex-1">
+                        <div class="flex items-center gap-2">
+                          <span class="text-sm font-medium text-[var(--text-strong)]">
                             {credential_display_name(credential)}
-                          </p>
-                          <span class={credential_type_badge_class(credential)}>
-                            {credential_type_label(credential)}
                           </span>
+                          <.status_badge status={credential_type(credential_form_params(credential))} />
                         </div>
-                        <p class="break-all font-mono text-xs text-neutral-500">
+                        <p class="mt-0.5 truncate font-mono text-[11px] text-[var(--text-muted)]">
                           {credential.mcp_server_url}
                         </p>
-                        <p class="text-xs uppercase tracking-[0.18em] text-neutral-400">
-                          Updated {ConsoleHelpers.format_timestamp(credential.updated_at)}
-                        </p>
                       </div>
-                      <.button
-                        id={"credential-rotate-button-#{credential.id}"}
-                        patch={
-                          ~p"/console/vaults/#{@selected_vault.id}/credentials/#{credential.id}/rotate"
-                        }
-                        class="rounded-full border border-neutral-300 bg-white px-4 text-neutral-800 hover:border-sky-300 hover:bg-sky-100"
-                      >
-                        Rotate
-                      </.button>
-                    </div>
+                      <.icon
+                        name="hero-arrow-path"
+                        class="ml-2 size-4 shrink-0 text-[var(--text-muted)]"
+                      />
+                    </.link>
                   </div>
-                </div>
+                <% end %>
               </div>
 
-              <div class="space-y-5">
-                <div>
-                  <p class="text-xs font-semibold uppercase tracking-[0.24em] text-sky-700">
-                    {credential_mode_label(@selected_credential)}
-                  </p>
-                  <h3 class="mt-2 text-xl font-semibold tracking-tight text-neutral-950">
-                    {credential_form_title(@selected_credential)}
-                  </h3>
-                  <p class="mt-1 text-sm leading-6 text-neutral-600">
-                    {credential_form_description(@selected_credential)}
-                  </p>
-                </div>
+              <div
+                :if={@show_credential_form || @selected_credential}
+                class="space-y-3 rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-bg)] p-4"
+              >
+                <h3 class="text-sm font-semibold text-[var(--text-strong)]">
+                  {if @selected_credential, do: "Rotate Credential", else: "New Credential"}
+                </h3>
 
                 <div
                   :if={@credential_errors != []}
                   id="credential-error-list"
-                  class="rounded-[1.5rem] border border-rose-200 bg-rose-50 px-5 py-4 text-sm text-rose-900"
+                  class="rounded-[8px] border border-[var(--danger)]/20 bg-[var(--danger-soft)] px-4 py-3 text-sm text-[var(--text-strong)]"
                 >
-                  <p class="font-semibold">Credential could not be saved.</p>
-                  <p :for={error <- @credential_errors} class="mt-2">{error}</p>
+                  <p :for={error <- @credential_errors}>{error}</p>
                 </div>
 
                 <div
                   :if={@selected_credential}
-                  class="rounded-[1.5rem] border border-neutral-200 bg-neutral-50 p-4"
+                  class="space-y-1 rounded-[8px] border border-[var(--border-subtle)] bg-[var(--panel-muted)] p-3 text-xs"
                 >
-                  <p class="text-xs font-semibold uppercase tracking-[0.22em] text-neutral-500">
-                    Locked fields
+                  <p class="font-medium text-[var(--text-strong)]">Locked routing fields</p>
+                  <p class="text-[var(--text-muted)]">
+                    {credential_display_name(@selected_credential)} · {credential_type_label(
+                      @selected_credential
+                    )} · {@selected_credential.mcp_server_url}
                   </p>
-                  <div class="mt-4 grid gap-4 md:grid-cols-2">
-                    <div>
-                      <p class="text-xs uppercase tracking-[0.18em] text-neutral-400">Type</p>
-                      <p class="mt-1 font-medium text-neutral-900">
-                        {credential_type_label(@selected_credential)}
-                      </p>
-                    </div>
-                    <div>
-                      <p class="text-xs uppercase tracking-[0.18em] text-neutral-400">
-                        MCP server URL
-                      </p>
-                      <p class="mt-1 break-all font-mono text-xs text-neutral-700">
-                        {@selected_credential.mcp_server_url}
-                      </p>
-                    </div>
-                    <div :if={@selected_credential.type == :mcp_oauth}>
-                      <p class="text-xs uppercase tracking-[0.18em] text-neutral-400">
-                        Token endpoint
-                      </p>
-                      <p class="mt-1 break-all font-mono text-xs text-neutral-700">
-                        {@selected_credential.token_endpoint || "Not stored"}
-                      </p>
-                    </div>
-                    <div :if={@selected_credential.type == :mcp_oauth}>
-                      <p class="text-xs uppercase tracking-[0.18em] text-neutral-400">Client ID</p>
-                      <p class="mt-1 break-all font-mono text-xs text-neutral-700">
-                        {@selected_credential.client_id || "Not stored"}
-                      </p>
-                    </div>
-                  </div>
                 </div>
 
                 <.form
                   for={@credential_form}
                   id="credential-form"
-                  class="space-y-5"
+                  class="space-y-3"
                   phx-change="validate_credential"
                   phx-submit="save_credential"
                 >
-                  <div class="grid gap-5 md:grid-cols-2">
+                  <div :if={is_nil(@selected_credential)} class="space-y-3">
                     <.input
                       field={@credential_form[:display_name]}
-                      label="Display name"
+                      label="Display Name"
                       placeholder="Alice's Slack"
                     />
                     <.input
                       field={@credential_form[:type]}
                       type="select"
-                      label="Credential type"
+                      label="Credential Type"
                       options={credential_type_options()}
-                      disabled={not is_nil(@selected_credential)}
                     />
                     <.input
                       field={@credential_form[:mcp_server_url]}
-                      label="MCP server URL"
-                      placeholder="https://mcp.slack.com/mcp"
-                      disabled={not is_nil(@selected_credential)}
+                      label="MCP Server URL"
+                      placeholder="https://mcp.example.com/sse"
                     />
-                    <div class="rounded-[1.5rem] border border-neutral-200 bg-neutral-50 p-4">
-                      <p class="text-sm font-medium text-neutral-900">Routing rule</p>
-                      <p class="mt-2 text-sm leading-6 text-neutral-600">
-                        One credential route matches one MCP server URL inside this vault.
-                      </p>
-                    </div>
-                  </div>
-
-                  <div
-                    :if={credential_type(@credential_form_params) == "static_bearer"}
-                    class="rounded-[1.5rem] border border-neutral-200 bg-neutral-50 p-4"
-                  >
-                    <.input
-                      field={@credential_form[:token]}
-                      type="password"
-                      label={secret_label(@selected_credential, "Bearer token")}
-                      placeholder={secret_placeholder(@selected_credential, "Enter a bearer token")}
-                    />
-                    <p class="mt-2 text-sm leading-6 text-neutral-500">
-                      Write-only. The stored bearer token is never displayed again after save.
+                    <p class="text-[10px] text-[var(--text-muted)]">
+                      One credential per MCP server URL per vault.
                     </p>
                   </div>
 
-                  <div :if={credential_type(@credential_form_params) == "mcp_oauth"} class="space-y-5">
-                    <div class="grid gap-5 md:grid-cols-2">
+                  <div :if={credential_type(@credential_form_params) == "static_bearer"}>
+                    <.input
+                      field={@credential_form[:token]}
+                      type="password"
+                      label={secret_label(@selected_credential, "Bearer Token")}
+                      placeholder={secret_placeholder(@selected_credential, "Enter token")}
+                    />
+                  </div>
+
+                  <div :if={credential_type(@credential_form_params) == "mcp_oauth"} class="space-y-3">
+                    <div class="grid gap-3 sm:grid-cols-2">
                       <.input
                         field={@credential_form[:access_token]}
                         type="password"
-                        label={secret_label(@selected_credential, "Access token")}
-                        placeholder={
-                          secret_placeholder(@selected_credential, "Enter a fresh access token")
-                        }
+                        label={secret_label(@selected_credential, "Access Token")}
+                        placeholder={secret_placeholder(@selected_credential, "")}
+                      />
+                      <.input
+                        field={@credential_form[:token_endpoint]}
+                        label="Token Endpoint"
+                        disabled={not is_nil(@selected_credential)}
+                      />
+                      <.input
+                        field={@credential_form[:client_id]}
+                        label="Client ID"
+                        disabled={not is_nil(@selected_credential)}
                       />
                       <.input
                         field={@credential_form[:expires_at]}
-                        label="Expires at"
-                        placeholder="2026-05-15T00:00:00Z"
+                        label="Expires At"
+                        placeholder="2026-05-01T00:00:00Z"
                       />
                     </div>
 
-                    <div class="rounded-[1.5rem] border border-neutral-200 bg-neutral-50 p-4">
-                      <p class="text-sm font-medium text-neutral-900">Refresh block</p>
-                      <p class="mt-2 text-sm leading-6 text-neutral-600">
-                        Token endpoint and client ID are locked after creation. Rotation only updates the secrets and other public surface metadata.
-                      </p>
-                      <div class="mt-4 grid gap-5 md:grid-cols-2">
-                        <.input
-                          field={@credential_form[:token_endpoint]}
-                          label="Token endpoint"
-                          placeholder="https://slack.com/api/oauth.v2.access"
-                          disabled={not is_nil(@selected_credential)}
-                        />
-                        <.input
-                          field={@credential_form[:client_id]}
-                          label="Client ID"
-                          placeholder="1234567890.0987654321"
-                          disabled={not is_nil(@selected_credential)}
-                        />
+                    <details class="text-xs">
+                      <summary class="cursor-pointer py-2 text-[var(--text-muted)] hover:text-[var(--text-strong)]">
+                        Advanced OAuth fields
+                      </summary>
+                      <div class="mt-2 grid gap-3 sm:grid-cols-2">
                         <.input
                           field={@credential_form[:refresh_token]}
                           type="password"
-                          label={secret_label(@selected_credential, "Refresh token")}
-                          placeholder={
-                            secret_placeholder(@selected_credential, "Enter a refresh token")
-                          }
+                          label={secret_label(@selected_credential, "Refresh Token")}
+                          placeholder={secret_placeholder(@selected_credential, "")}
                         />
-                        <.input
-                          field={@credential_form[:refresh_scope]}
-                          label="Scope"
-                          placeholder="channels:read chat:write"
-                        />
+                        <.input field={@credential_form[:refresh_scope]} label="Scope" />
                         <.input
                           field={@credential_form[:token_endpoint_auth_type]}
-                          type="select"
-                          label="Token endpoint auth"
-                          options={token_endpoint_auth_type_options()}
+                          label="Auth Type"
+                          placeholder="client_secret_post"
                         />
                         <.input
                           field={@credential_form[:client_secret]}
                           type="password"
-                          label={secret_label(@selected_credential, "Client secret")}
-                          placeholder={
-                            secret_placeholder(@selected_credential, "Enter a client secret")
-                          }
+                          label={secret_label(@selected_credential, "Client Secret")}
+                          placeholder={secret_placeholder(@selected_credential, "")}
                         />
                       </div>
-                    </div>
+                    </details>
                   </div>
 
-                  <div class="rounded-[1.5rem] border border-neutral-200 bg-neutral-50 p-4">
-                    <.input
-                      field={@credential_form[:metadata_json]}
-                      type="textarea"
-                      label="Metadata JSON"
-                      rows="7"
-                      placeholder={"{\n  \"provider\": \"slack\"\n}"}
-                    />
-                    <p class="mt-2 text-sm leading-6 text-neutral-500">
-                      Optional public metadata returned in safe credential responses. Secret material never appears here.
-                    </p>
-                  </div>
+                  <.input
+                    field={@credential_form[:metadata_json]}
+                    type="textarea"
+                    label="Metadata JSON"
+                    rows="2"
+                  />
 
-                  <div class="flex flex-wrap gap-3">
+                  <div class="flex flex-wrap gap-2">
                     <.button
                       id="credential-save-button"
-                      class="rounded-full bg-sky-600 px-5 text-white hover:bg-sky-500"
+                      class="console-button console-button-primary"
                     >
-                      {credential_submit_label(@selected_credential)}
+                      {if @selected_credential, do: "Rotate Credential", else: "Create Credential"}
                     </.button>
-                    <.button
-                      :if={@selected_credential}
+                    <.link
                       patch={~p"/console/vaults/#{@selected_vault.id}"}
-                      class="rounded-full border border-neutral-300 bg-white px-5 text-neutral-800 hover:border-neutral-400 hover:bg-neutral-50"
+                      class="console-button console-button-secondary"
                     >
-                      Back to new credential
-                    </.button>
+                      Cancel
+                    </.link>
                   </div>
                 </.form>
               </div>
             </div>
-          </div>
+          <% else %>
+            <.empty_state
+              title="No vault selected"
+              description="Select a vault from the list or create a new one."
+            />
+          <% end %>
         </section>
       </div>
     </Layouts.app>
-    """
-  end
-
-  attr :label, :string, required: true
-  attr :value, :integer, required: true
-
-  defp metric_card(assigns) do
-    ~H"""
-    <div>
-      <p class="text-xs uppercase tracking-[0.2em] text-sky-100/70">{@label}</p>
-      <p class="mt-2 text-3xl font-semibold tracking-tight">{@value}</p>
-    </div>
-    """
-  end
-
-  attr :label, :string, required: true
-  attr :active, :boolean, default: false
-  attr :navigate, :string, default: nil
-
-  defp console_tab(%{navigate: nil} = assigns) do
-    ~H"""
-    <span class="inline-flex items-center rounded-full border border-white/15 bg-white/12 px-4 py-2 text-sm font-medium text-white">
-      {@label}
-    </span>
-    """
-  end
-
-  defp console_tab(assigns) do
-    ~H"""
-    <.link
-      navigate={@navigate}
-      class={[
-        "inline-flex items-center rounded-full px-4 py-2 text-sm font-medium transition",
-        @active && "border border-white/15 bg-white/12 text-white",
-        !@active &&
-          "border border-white/10 bg-black/10 text-white/75 hover:bg-white/10 hover:text-white"
-      ]}
-    >
-      {@label}
-    </.link>
     """
   end
 
@@ -753,6 +588,8 @@ defmodule JidoManagedAgentsWeb.VaultConsoleLive do
     socket
     |> assign(:vaults, list_vaults(actor))
     |> assign(:total_credential_count, count_credentials(actor))
+    |> assign(:show_create_vault, false)
+    |> assign(:show_credential_form, false)
     |> assign(:vault_errors, [])
     |> assign_vault_form(default_vault_params())
     |> put_flash(:info, "Vault created.")
@@ -945,6 +782,7 @@ defmodule JidoManagedAgentsWeb.VaultConsoleLive do
     |> assign(:total_credential_count, count_credentials(actor))
     |> assign(:credentials, list_credentials(vault, actor))
     |> assign(:selected_credential, nil)
+    |> assign(:show_credential_form, false)
     |> assign(:credential_errors, [])
     |> assign_credential_form(default_credential_params())
     |> put_flash(:info, credential_saved_message(socket.assigns.selected_credential))
@@ -1001,30 +839,6 @@ defmodule JidoManagedAgentsWeb.VaultConsoleLive do
     serialized.display_name || vault.name
   end
 
-  defp vault_card_class(vault, selected_vault) do
-    selected? = selected_vault && selected_vault.id == vault.id
-
-    [
-      "rounded-[1.5rem] border p-4 transition",
-      if(selected?,
-        do: "border-sky-300 bg-sky-50/70 shadow-sm shadow-sky-100",
-        else: "border-neutral-200 bg-white hover:border-sky-200 hover:bg-sky-50/40"
-      )
-    ]
-  end
-
-  defp credential_card_class(credential, selected_credential) do
-    selected? = selected_credential && selected_credential.id == credential.id
-
-    [
-      "rounded-[1.25rem] border p-4 transition",
-      if(selected?,
-        do: "border-sky-300 bg-sky-100/60 shadow-sm shadow-sky-100",
-        else: "border-neutral-200 bg-white hover:border-sky-200 hover:bg-sky-50/50"
-      )
-    ]
-  end
-
   defp credential_display_name(credential) do
     serialized = CredentialDefinition.serialize_credential(credential)
     serialized[:display_name] || credential.mcp_server_url
@@ -1040,34 +854,9 @@ defmodule JidoManagedAgentsWeb.VaultConsoleLive do
     end
   end
 
-  defp credential_type_badge_class(%Credential{type: :static_bearer}) do
-    "inline-flex items-center rounded-full bg-emerald-100 px-2.5 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-emerald-900"
-  end
-
-  defp credential_type_badge_class(%Credential{type: :mcp_oauth}) do
-    "inline-flex items-center rounded-full bg-violet-100 px-2.5 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-violet-900"
-  end
-
   defp credential_type(form_params) do
     Map.get(form_params, "type", "mcp_oauth")
   end
-
-  defp credential_mode_label(nil), do: "Add credential"
-  defp credential_mode_label(_credential), do: "Rotate credential"
-
-  defp credential_form_title(nil), do: "New credential"
-  defp credential_form_title(_credential), do: "Rotate credential"
-
-  defp credential_form_description(nil) do
-    "Create a safe routing record for one MCP server URL. Secret inputs are stored as provided and never shown again."
-  end
-
-  defp credential_form_description(_credential) do
-    "Rotation updates secret values and public metadata only. Immutable auth routing fields stay locked so existing session matching does not drift."
-  end
-
-  defp credential_submit_label(nil), do: "Save credential"
-  defp credential_submit_label(_credential), do: "Rotate credential"
 
   defp credential_saved_message(nil), do: "Credential saved."
   defp credential_saved_message(_credential), do: "Credential rotated."
@@ -1078,22 +867,25 @@ defmodule JidoManagedAgentsWeb.VaultConsoleLive do
   defp secret_placeholder(nil, placeholder), do: placeholder
   defp secret_placeholder(_credential, placeholder), do: "#{placeholder} or leave blank"
 
+  defp selected_vault?(nil, _vault), do: false
+  defp selected_vault?(%Vault{id: id}, %Vault{id: id}), do: true
+  defp selected_vault?(_selected_vault, _vault), do: false
+
+  defp credential_count(vault, %Vault{id: id}, credentials) when vault.id == id,
+    do: length(credentials)
+
+  defp credential_count(_vault, _selected_vault, _credentials), do: 0
+
   defp stringify_keys(map) when is_map(map) do
     Map.new(map, fn {key, value} -> {to_string(key), value} end)
   end
+
+  defp stringify_keys(value), do: value
 
   defp credential_type_options do
     [
       {"MCP OAuth", "mcp_oauth"},
       {"Static bearer token", "static_bearer"}
-    ]
-  end
-
-  defp token_endpoint_auth_type_options do
-    [
-      {"Client secret in POST body", "client_secret_post"},
-      {"HTTP Basic auth", "client_secret_basic"},
-      {"Public client / none", "none"}
     ]
   end
 end

--- a/lib/jido_managed_agents_web/live_user_auth.ex
+++ b/lib/jido_managed_agents_web/live_user_auth.ex
@@ -37,7 +37,7 @@ defmodule JidoManagedAgentsWeb.LiveUserAuth do
 
   def on_mount(:live_no_user, _params, _session, socket) do
     if socket.assigns[:current_user] do
-      {:halt, Phoenix.LiveView.redirect(socket, to: ~p"/")}
+      {:halt, Phoenix.LiveView.redirect(socket, to: ~p"/console")}
     else
       {:cont,
        socket |> assign(:current_user, nil) |> JidoManagedAgents.AshActor.assign_socket_actor()}

--- a/lib/jido_managed_agents_web/router.ex
+++ b/lib/jido_managed_agents_web/router.ex
@@ -54,12 +54,16 @@ defmodule JidoManagedAgentsWeb.Router do
     pipe_through(:browser)
 
     ash_authentication_live_session :authenticated_routes do
+      live("/console", OverviewLive, :index)
+      live("/console/agents", AgentsLibraryLive, :index)
       live("/console/agents/new", AgentBuilderLive, :new)
       live("/console/agents/:id/edit", AgentBuilderLive, :edit)
+      live("/console/agents/:id", AgentDetailLive, :show)
       live("/console/environments", EnvironmentConsoleLive, :index)
       live("/console/environments/:id/edit", EnvironmentConsoleLive, :edit)
       live("/console/sessions", SessionObservabilityLive, :index)
       live("/console/sessions/:id", SessionObservabilityLive, :show)
+      live("/console/api-docs", ApiDocsLive, :index)
       live("/console/vaults", VaultConsoleLive, :index)
 
       live(

--- a/test/jido_managed_agents_web/controllers/page_controller_test.exs
+++ b/test/jido_managed_agents_web/controllers/page_controller_test.exs
@@ -5,8 +5,11 @@ defmodule JidoManagedAgentsWeb.PageControllerTest do
     conn = get(conn, ~p"/")
     html = html_response(conn, 200)
 
-    assert html =~ "Build, run, and inspect managed agents without losing the thread."
-    assert html =~ "Open source control plane for agent execution"
+    assert html =~ "Open-source control plane for managed AI agents"
+
+    assert html =~
+             "Author versioned agents, attach tools and MCP servers, isolate runtimes with environment templates"
+
     assert html =~ "Create Account"
   end
 end

--- a/test/jido_managed_agents_web/live/agent_builder_live_test.exs
+++ b/test/jido_managed_agents_web/live/agent_builder_live_test.exs
@@ -48,10 +48,13 @@ defmodule JidoManagedAgentsWeb.AgentBuilderLiveTest do
     {:ok, view, _html} = live(conn, ~p"/console/agents/new")
 
     assert has_element?(view, "#agent-builder-form")
+    render_click(element(view, "button[phx-value-section='capabilities']"))
     assert has_element?(view, "#add-tool-button")
     assert has_element?(view, "#add-mcp-server-button")
     assert has_element?(view, "#add-skill-button")
     assert has_element?(view, "#add-callable-agent-button")
+
+    render_click(element(view, "button[phx-click='toggle_preview_expanded']"))
     assert has_element?(view, "#api-preview")
     assert has_element?(view, "#yaml-preview")
 
@@ -90,7 +93,8 @@ defmodule JidoManagedAgentsWeb.AgentBuilderLiveTest do
 
     assert updated_agent.latest_version.version == 2
     assert updated_agent.latest_version.name == "Research Coordinator v2"
-    assert element(edit_view, "#version-list") |> render() =~ "Version 2"
+    render_click(element(edit_view, "button[phx-click='toggle_version_history']"))
+    assert element(edit_view, "#version-list") |> render() =~ "v2"
   end
 
   test "launches a session inline and streams output without leaving the page", %{conn: conn} do
@@ -103,6 +107,8 @@ defmodule JidoManagedAgentsWeb.AgentBuilderLiveTest do
     vault = create_vault!(user)
 
     {:ok, view, _html} = live(conn, ~p"/console/agents/#{agent.id}/edit")
+
+    render_click(element(view, "button[phx-value-section='testrun']"))
 
     render_submit(element(view, "#agent-runner-form"), %{
       "runner" => %{
@@ -142,6 +148,8 @@ defmodule JidoManagedAgentsWeb.AgentBuilderLiveTest do
       create_session!(user, agent, version, environment, workspace, %{title: "Existing Session"})
 
     {:ok, view, _html} = live(conn, ~p"/console/agents/#{agent.id}/edit")
+
+    render_click(element(view, "button[phx-value-section='testrun']"))
 
     render_submit(element(view, "#agent-runner-form"), %{
       "runner" => %{

--- a/test/jido_managed_agents_web/live/auth_live_test.exs
+++ b/test/jido_managed_agents_web/live/auth_live_test.exs
@@ -1,0 +1,12 @@
+defmodule JidoManagedAgentsWeb.AuthLiveTest do
+  use JidoManagedAgentsWeb.ConnCase, async: false
+
+  test "authenticated users are redirected from sign-in and register to the console", %{
+    conn: conn
+  } do
+    %{conn: conn} = register_and_log_in_user(%{conn: conn})
+
+    assert {:error, {:redirect, %{to: "/console"}}} = live(conn, ~p"/sign-in")
+    assert {:error, {:redirect, %{to: "/console"}}} = live(conn, ~p"/register")
+  end
+end

--- a/test/jido_managed_agents_web/live/resource_console_live_test.exs
+++ b/test/jido_managed_agents_web/live/resource_console_live_test.exs
@@ -46,7 +46,7 @@ defmodule JidoManagedAgentsWeb.ResourceConsoleLiveTest do
     {:ok, edit_view, edit_html} =
       live(conn, ~p"/console/environments/#{created_environment.id}/edit")
 
-    assert edit_html =~ "Edit environment"
+    assert edit_html =~ "Edit: Delivery Sandbox"
 
     render_submit(element(edit_view, "#environment-form"), %{
       "environment" =>
@@ -77,6 +77,8 @@ defmodule JidoManagedAgentsWeb.ResourceConsoleLiveTest do
     assert html =~ "Vaults"
     refute html =~ "Other User Vault"
 
+    render_click(element(view, "button[phx-click='toggle_create_vault']"))
+
     render_submit(element(view, "#vault-form"), %{
       "vault" => vault_params("Alice Vault")
     })
@@ -84,9 +86,11 @@ defmodule JidoManagedAgentsWeb.ResourceConsoleLiveTest do
     vault = get_vault_by_name!(user, "Alice Vault")
 
     assert_patch(view, ~p"/console/vaults/#{vault.id}")
-    assert render(view) =~ "Write-only secret fields"
+    assert render(view) =~ "Secrets are write-only. Stored values cannot be retrieved."
 
     access_token = "lin_api_#{System.unique_integer([:positive])}"
+
+    render_click(element(view, "#show-credential-form-button"))
 
     render_submit(element(view, "#credential-form"), %{
       "credential" => static_credential_params("Linear API key", access_token)
@@ -124,7 +128,7 @@ defmodule JidoManagedAgentsWeb.ResourceConsoleLiveTest do
     {:ok, view, html} =
       live(conn, ~p"/console/vaults/#{vault.id}/credentials/#{credential.id}/rotate")
 
-    assert html =~ "Locked fields"
+    assert html =~ "Locked routing fields"
     assert html =~ "leave blank to keep current"
 
     render_submit(element(view, "#credential-form"), %{

--- a/test/jido_managed_agents_web/live/session_observability_live_test.exs
+++ b/test/jido_managed_agents_web/live/session_observability_live_test.exs
@@ -47,12 +47,20 @@ defmodule JidoManagedAgentsWeb.SessionObservabilityLiveTest do
 
     {:ok, detail_view, detail_html} = live(conn, ~p"/console/sessions/#{session.id}")
 
-    assert detail_html =~ "Trace Timeline"
-    assert detail_html =~ "Tool Execution"
-    assert detail_html =~ "Raw Events"
+    assert detail_html =~ "Transcript"
+    assert detail_html =~ "Debug"
+    assert detail_html =~ "All traces"
+
+    render_click(element(detail_view, "button[phx-value-view='debug']"))
+    render_click(element(detail_view, "button[phx-value-tab='tools']"))
+
     assert element(detail_view, "#session-tool-executions") |> render() =~ "ls -la"
     assert element(detail_view, "#session-tool-executions") |> render() =~ "total 0"
+
+    render_click(element(detail_view, "button[phx-value-tab='raw']"))
     assert element(detail_view, "#session-raw-events") |> render() =~ "agent.message"
+
+    render_click(element(detail_view, "button[phx-value-tab='metrics']"))
 
     metrics_html = element(detail_view, "#session-metrics") |> render()
 
@@ -70,8 +78,13 @@ defmodule JidoManagedAgentsWeb.SessionObservabilityLiveTest do
 
     assert html =~ "Latest error"
     assert html =~ "Anthropic request timed out"
+
+    render_click(element(view, "button[phx-value-view='debug']"))
+    render_click(element(view, "button[phx-value-tab='raw']"))
     assert element(view, "#session-raw-events") |> render() =~ "session.error"
-    assert element(view, "#session-metrics") |> render() =~ "No provider metrics were recorded"
+
+    render_click(element(view, "button[phx-value-tab='metrics']"))
+    assert element(view, "#session-metrics") |> render() =~ "No provider metrics"
   end
 
   test "approval-needed sessions render allow and deny controls for blocked tool uses", %{
@@ -91,7 +104,7 @@ defmodule JidoManagedAgentsWeb.SessionObservabilityLiveTest do
     assert has_element?(view, "#confirm-deny-#{blocked_tool_use_event.id}")
 
     assert element(view, "#pending-confirmation-#{blocked_tool_use_event.id}") |> render() =~
-             "user.tool_confirmation"
+             "rm -rf tmp/build"
   end
 
   test "threaded sessions support drill-down into thread-specific traces", %{conn: conn} do
@@ -112,6 +125,9 @@ defmodule JidoManagedAgentsWeb.SessionObservabilityLiveTest do
     assert_patch(view, ~p"/console/sessions/#{session.id}?thread_id=#{delegate_thread.id}")
 
     thread_trace = element(view, "#session-trace") |> render()
+
+    render_click(element(view, "button[phx-value-view='debug']"))
+    render_click(element(view, "button[phx-value-tab='raw']"))
     raw_html = element(view, "#session-raw-events") |> render()
 
     assert thread_trace =~ "Delegate trace ready."


### PR DESCRIPTION
## Summary
- port the console shell and landing page styling to a LiveView-first Phoenix UI
- add dedicated LiveViews for overview, agent detail, agent library, and API docs, and refresh the existing environment, session, vault, and builder screens
- wire the authenticated console routes and auth redirects so signed-in users land in the new console flow
- expand the LiveView/controller coverage for the new console behavior

## Testing
- mix precommit